### PR TITLE
Set port and tlsPort when retrieving configuration

### DIFF
--- a/src/lib/kinetic_device_info.c
+++ b/src/lib/kinetic_device_info.c
@@ -140,6 +140,11 @@ static KineticLogInfo_Configuration * KineticLogInfo_GetConfiguration(
         cfg->protocolSourceHash = copy_str(gcfg->protocolsourcehash);
         if (cfg->protocolSourceHash == NULL) { goto cleanup; }
 
+	if (gcfg->has_port)
+		cfg->port = gcfg->port;
+	if (gcfg->has_tlsport)
+		cfg->tlsPort = gcfg->tlsport;
+
         cfg->numInterfaces = gcfg->n_interface;
         cfg->interfaces = calloc(cfg->numInterfaces, sizeof(*cfg->interfaces));
         if (cfg->interfaces == NULL) { goto cleanup; }


### PR DESCRIPTION
GetLog for KINETIC_DEVICE_INFO_TYPE_CONFIGURATION was returning 0 for both