### PR TITLE
fix Apple OSX build issue

### DIFF
--- a/src/lib/kinetic_socket.c
+++ b/src/lib/kinetic_socket.c
@@ -165,7 +165,7 @@ void KineticSocket_BeginPacket(int fd)
     int on = 1;
     setsockopt(fd, IPPROTO_TCP, TCP_CORK, &on, sizeof(on));
 #else
-    (void)socket;
+    (void)fd;
 #endif
 }
 
@@ -175,6 +175,6 @@ void KineticSocket_FinishPacket(int fd)
     int off = 0;
     setsockopt(fd, IPPROTO_TCP, TCP_CORK, &off, sizeof(off));
 #else
-    (void)socket;
+    (void)fd;
 #endif
 }


### PR DESCRIPTION
Fix build issue introduced by commit 9b0b8c1cbd1d945fb096d6130f18c99ca901e567
"Local variable names shadowed global function names (e.g. read),
this would cause compile errors with gcc 4.4.7."