### PR TITLE
fix travis-ci OSX build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,13 @@ compiler:
   - clang
   - gcc
 before_script:
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo apt-get update -qq
-  - sudo apt-get install -y gcc-4.8
-  - if [ $CC == 'gcc' ]; then export CC=gcc-4.8; fi;
+  - if [ "$TRAVIS_OS_NAME" = "linux" ] ; then sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ] ; then sudo apt-get update -qq; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ] ; then sudo apt-get install -y gcc-4.8; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx"   ] ; then sudo brew update ; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx"   ] ; then sudo brew outdated openssl || brew upgrade openssl ; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx"   ] ; then export OPENSSL_PATH=/usr/local/opt/openssl ; fi
+  - if [ $CC == 'gcc'                ] ; then export CC=gcc-4.8; fi;
   - bundle install
   - make clean
   - make start_simulator


### PR DESCRIPTION
The OSX Travis-ci build was failing because it was trying to do Linux apt commands instead of Homebrew commands.

This commit fixes the problem by executing the APT commands for Linux builds and the Homebrew commands for OSX builds, and has been tested & verified against my fork
