### PR TITLE
Fix MediaOptimize to actually use MEDIAOPTIMIZE instead of MEDIASCAN

### DIFF
--- a/src/lib/kinetic_builder.c
+++ b/src/lib/kinetic_builder.c
@@ -482,7 +482,7 @@ KineticStatus KineticBuilder_BuildMediaOptimize(KineticOperation* const op,
 {
     KineticOperation_ValidateOperation(op);
 
-    op->request->message.command.header->messagetype = COM__SEAGATE__KINETIC__PROTO__COMMAND__MESSAGE_TYPE__MEDIASCAN;
+    op->request->message.command.header->messagetype = COM__SEAGATE__KINETIC__PROTO__COMMAND__MESSAGE_TYPE__MEDIAOPTIMIZE;
     initRangeAndPriority(op, mediaoptimize_operation, priority);
     op->timeoutSeconds = KineticOperation_TimeoutMediaOptimize;
 


### PR DESCRIPTION
A call to MediaOptimize was actually sending a MEDIASCAN message.  It was probably a cut-n-paste error from the original creation of this code.