### PR TITLE
Master fix whitespace

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -102,7 +102,7 @@ Future development notes
   on Linux.
 
 * The listener can potentially leak memory on shutdown, in the case
-  where responses have been partially received. This has been a low priority. 
+  where responses have been partially received. This has been a low priority.
 
 * There is room for tuning the total number of messages-in-flight
   in the listener (controlled by `MAX_PENDING_MESSAGES`), how the

--- a/LICENSE
+++ b/LICENSE
@@ -35,7 +35,7 @@ Mozilla Public License Version 2.0
     means any form of the work other than Source Code Form.
 
 1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in 
+    means a work that combines Covered Software with other material, in
     a separate file or files, that is not Covered Software.
 
 1.8. "License"

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ OPTIMIZE = -O3
 KINETIC_HOST1 ?= localhost
 SESSION_HMAC_KEY ?= asdfasdf
 SESSION_PIN ?= 1234
-WARN = -Wall -Wextra -Wstrict-prototypes -Wcast-align -pedantic 
+WARN = -Wall -Wextra -Wstrict-prototypes -Wcast-align -pedantic
 WARN += -Wno-missing-field-initializers -Werror=strict-prototypes -Wshadow
 WARN += -Werror
 CDEFS += -D_POSIX_C_SOURCE=199309L -D_C99_SOURCE=1
@@ -174,7 +174,7 @@ $(OUT_DIR)/%.o: ${LIB_DIR}/bus/%.c ${LIB_DIR}/bus/%.h
 ${OUT_DIR}/*.o: src/lib/kinetic_types_internal.h
 
 ci: stop_sims start_sims all stop_sims
-	@echo 
+	@echo
 	@echo --------------------------------------------------------------------------------
 	@echo Testing install/uninstall of kinetic-c
 	@echo --------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Prerequisites
         * via Git submodule (from bundled source)
             * `> make json`
             * `> sudo make install_json`
-            
+
 A release of OpenSSL that provides TLS 1.1 or newer is required.
 
 If the OpenSSL installation is not found, the `OPENSSL_PATH` environment

--- a/config/license_template
+++ b/config/license_template
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/include/kinetic_admin_client.h
+++ b/include/kinetic_admin_client.h
@@ -26,9 +26,9 @@
  *
  * @param config A configuration struct.
  *
- * @return          Returns a pointer to a KineticClient. You need to pass 
- *                  this pointer to KineticClient_CreateSession() to create 
- *                  new connections. 
+ * @return          Returns a pointer to a KineticClient. You need to pass
+ *                  this pointer to KineticClient_CreateSession() to create
+ *                  new connections.
  *                  Once you are finished will the KineticClient, and there
  *                  are no active connections. The pointer should be released
  *                  with KineticClient_Shutdown()

--- a/include/kinetic_client.h
+++ b/include/kinetic_client.h
@@ -22,7 +22,7 @@
 
 /**
  * @brief Gets current version info of kinetic-c library
- * 
+ *
  * @return Returns a pointer to static version info
  */
 const KineticVersionInfo * KineticClient_Version(void);
@@ -32,9 +32,9 @@ const KineticVersionInfo * KineticClient_Version(void);
  *
  * @param config A configuration struct.
  *
- * @return          Returns a pointer to a KineticClient. You need to pass 
- *                  this pointer to KineticClient_CreateSession() to create 
- *                  new connections. 
+ * @return          Returns a pointer to a KineticClient. You need to pass
+ *                  this pointer to KineticClient_CreateSession() to create
+ *                  new connections.
  *                  Once you are finished will the KineticClient, and there
  *                  are no active connections. The pointer should be release
  *                  with KineticClient_Shutdown()
@@ -43,9 +43,9 @@ KineticClient * KineticClient_Init(KineticClientConfig *config);
 
 /**
  * @brief Performs shutdown/cleanup of the kinetic-c client library
- * 
+ *
  * @param client The pointer returned from `KineticClient_Init`
- * 
+ *
  */
 void KineticClient_Shutdown(KineticClient * const client);
 
@@ -88,9 +88,9 @@ KineticStatus KineticClient_DestroySession(KineticSession * const session);
 /**
  * @brief Returns the reason reported in the case of the Kinetic device
  * terminating a session in the case of a catastrophic error occurring.
- * 
+ *
  * @param session       The KineticSession to query.
- * 
+ *
  * @return              Returns the status reported prior to termination
  *                      or KINTEIC_STATUS_SUCCESS if not terminated.
  */
@@ -117,7 +117,7 @@ KineticStatus KineticClient_NoOp(KineticSession* const session);
  * @param closure       Optional closure. If specified, operation will be
  *                      executed in asynchronous mode, and closure callback
  *                      will be called upon completion in another thread.
- * 
+ *
  * @return              Returns the resulting KineticStatus.
  */
 KineticStatus KineticClient_Put(KineticSession* const session,
@@ -131,7 +131,7 @@ KineticStatus KineticClient_Put(KineticSession* const session,
  * @param closure       Optional closure. If specified, operation will be
  *                      executed in asynchronous mode, and closure callback
  *                      will be called upon completion in another thread.
- *                      
+ *
  * @return              Returns the resulting KineticStatus.
  */
 KineticStatus KineticClient_Flush(KineticSession* const session,
@@ -166,7 +166,7 @@ KineticStatus KineticClient_Get(KineticSession* const session,
  *                      lexicographical byte order. If a closure is provided
  *                      this pointer must remain valid until the closure callback
  *                      is called.
- *                      
+ *
  * @param closure       Optional closure. If specified, operation will be
  *                      executed in asynchronous mode, and closure callback
  *                      will be called upon completion in another thread.
@@ -188,7 +188,7 @@ KineticStatus KineticClient_GetPrevious(KineticSession* const session,
  *                      lexicographical byte order. If a closure is provided
  *                      this pointer must remain valid until the closure callback
  *                      is called.
- *                      
+ *
  * @param closure       Optional closure. If specified, operation will be
  *                      executed in asynchronous mode, and closure callback
  *                      will be called upon completion in another thread.
@@ -221,7 +221,7 @@ KineticStatus KineticClient_Delete(KineticSession* const session,
  *
  * @param session       The connected KineticSession to use for the operation
  * @param range         KineticKeyRange specifying keys to return
- * @param keys          ByteBufferArray to store the retrieved keys. If a 
+ * @param keys          ByteBufferArray to store the retrieved keys. If a
  *                      closure is provided, this must point to valid memory
  *                      until the closure callback is called.
  * @param closure       Optional closure. If specified, operation will be
@@ -243,7 +243,7 @@ KineticStatus KineticClient_GetKeyRange(KineticSession* const session,
  *
  * @param session       The connected KineticSession to use for the operation
  * @param p2pOp         KineticP2P_Operation pointer. This pointer needs to remain
- *                      valid during the duration of the operation. The results of 
+ *                      valid during the duration of the operation. The results of
  *                      P2P operation(s) will be stored in the resultStatus field of
  *                      this structure.
  * @param closure       Optional closure. If specified, operation will be
@@ -252,7 +252,7 @@ KineticStatus KineticClient_GetKeyRange(KineticSession* const session,
  *
  * @return              Returns 0 upon success, -1 or the Kinetic status code
  *                      upon failure. Note that P2P operations can be nested. This
- *                      status code pertains to the initial top-level P2P operation. 
+ *                      status code pertains to the initial top-level P2P operation.
  *                      You'll need to check the resultStatus in the p2pOp structure
  *                      to check the status of the individual P2P operations.
  */

--- a/include/kinetic_semaphore.h
+++ b/include/kinetic_semaphore.h
@@ -23,7 +23,7 @@
 typedef struct _KineticSemaphore KineticSemaphore;
 
 /**
- * @brief Creates a KineticSemaphore. The KineticSemaphore is a simple wrapper 
+ * @brief Creates a KineticSemaphore. The KineticSemaphore is a simple wrapper
  *        around a pthread condition variable and provides a a thread-safe
  *        way to block a thread and wait for notification from another thread.
  *
@@ -32,7 +32,7 @@ typedef struct _KineticSemaphore KineticSemaphore;
 KineticSemaphore * KineticSemaphore_Create(void);
 
 /**
- * @brief Signals KineticSemaphore. This will unblock another 
+ * @brief Signals KineticSemaphore. This will unblock another
  *        thread that's blocked on the given semaphore using KineticSemaphore_WaitForSignalAndDestroy()
  *        You should never signal the same KineticSemaphore more than once.
  *
@@ -62,7 +62,7 @@ bool KineticSemaphore_DestroyIfSignaled(KineticSemaphore * sem);
 
 /**
  * @brief Blocks until the given semaphore is signaled. This will not block
- *        if the Semaphore has already been signaled. 
+ *        if the Semaphore has already been signaled.
  *        Once unblocked, this will also destroy (free) the provide KineticSemaphore.
  *
  * @param sem       A pointer to the semaphore to wait for a signal.

--- a/include/kinetic_types.h
+++ b/include/kinetic_types.h
@@ -34,7 +34,7 @@
 
 
 #define KINETIC_SOCKET_INVALID  (-1)                    ///< Invalid socket file descriptor value
-#define KINETIC_PORT            (8123)                  ///< Default kinetic port 
+#define KINETIC_PORT            (8123)                  ///< Default kinetic port
 #define KINETIC_TLS_PORT        (8443)                  ///< Default kinetic TLS port
 #define KINETIC_HMAC_SHA1_LEN   (SHA_DIGEST_LENGTH)     ///< HMAC secure hash length
 #define KINETIC_HMAC_MAX_LEN    (KINETIC_HMAC_SHA1_LEN) ///< HMAC max length
@@ -93,8 +93,8 @@ typedef enum _KineticSynchronization {
     /// or when a subsequent FLUSH is sent to the drive.
     KINETIC_SYNCHRONIZATION_WRITEBACK = 2,
 
-    /// All pending information that has not been written is 
-    /// pushed to the disk and the command that specifies 
+    /// All pending information that has not been written is
+    /// pushed to the disk and the command that specifies
     /// FLUSH is written last and then returned. All WRITEBACK writes
     /// that have received ending status will be guaranteed to be
     /// written before the FLUSH operation is returned completed.
@@ -190,9 +190,9 @@ typedef enum {
 
 /**
  * @brief Provides a string representation for a KineticStatus code.
- * 
+ *
  * @param status    The status enumeration value.
- * 
+ *
  * @return          Pointer to the appropriate string representation for the specified status.
  */
 const char* Kinetic_GetStatusDescription(KineticStatus status);
@@ -209,7 +209,7 @@ typedef struct _KineticCompletionData {
 
 /**
  * @brief Operation completion callback function prototype.
- * 
+ *
  * @param kinetic_data  KineticCompletionData provided by kinetic-c.
  * @param client_data   Optional pointer to arbitrary client-supplied data.
  */
@@ -230,7 +230,7 @@ typedef struct _KineticCompletionClosure {
  * The ByteBuffer attributes must be allocated and freed by the client, if used.
  */
 typedef struct _KineticEntry {
-    ByteBuffer key;             ///< Key associated with the object stored on disk 
+    ByteBuffer key;             ///< Key associated with the object stored on disk
     ByteBuffer value;           ///< Value data associated with the key
 
     // Metadata
@@ -248,7 +248,7 @@ typedef struct _KineticEntry {
 
 /**
  * @brief Kinetic Key Range request structure
- */ 
+ */
 typedef struct _KineticKeyRange {
 
     /// Required bytes, the beginning of the requested range
@@ -518,9 +518,9 @@ typedef struct {
 
 /**
  * @brief Provides a string representation for a Kinetic message type.
- * 
+ *
  * @param type  The message type value.
- * 
+ *
  * @return      Pointer to the appropriate string representation for the specified type.
  */
 const char* KineticMessageType_GetName(KineticMessageType type);

--- a/src/examples/blocking_flush.c
+++ b/src/examples/blocking_flush.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -66,7 +66,7 @@ int main(int argc, char** argv)
     }
 
     do_flush(session);
-    
+
     // Shutdown client connection and cleanup
     KineticClient_DestroySession(session);
     KineticClient_Shutdown(client);

--- a/src/examples/blocking_getkeyrange.c
+++ b/src/examples/blocking_getkeyrange.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -33,17 +33,17 @@ static void do_put_and_getkeyrange(KineticSession * const session) {
         char key[] = "keyX";
         key[3] = '0' + i;
         ByteBuffer put_key_buf = ByteBuffer_MallocAndAppend(key, strlen(key));
-        
+
         uint8_t value[] = "valueX";
         value[5] = '0' + i;
         ByteBuffer put_value_buf = ByteBuffer_MallocAndAppend(value, sizeof(value));
-        
+
         /* Populate tag with SHA1 of value */
         ByteBuffer put_tag_buf = ByteBuffer_Malloc(20);
         uint8_t sha1[20];
         SHA1(put_value_buf.array.data, put_value_buf.bytesUsed, &sha1[0]);
         ByteBuffer_Append(&put_tag_buf, sha1, sizeof(sha1));
-        
+
         KineticEntry put_entry = {
             .key = put_key_buf,
             .value = put_value_buf,
@@ -77,7 +77,7 @@ static void do_put_and_getkeyrange(KineticSession * const session) {
         .endKeyInclusive = true,
         .maxReturned = max_key_count,
     };
-    
+
     uint8_t key_mem[max_key_count][max_key_length];
     memset(key_mem, 0, sizeof(key_mem));
 
@@ -93,7 +93,7 @@ static void do_put_and_getkeyrange(KineticSession * const session) {
     /* Request the key range as specified in &range, populating the keys in &keys. */
     KineticStatus status = KineticClient_GetKeyRange(session, &range, &keys, NULL);
     printf("GetKeyRange status: %s\n", Kinetic_GetStatusDescription(status));
-    
+
     if (status == KINETIC_STATUS_SUCCESS) {
         for (size_t i = 0; i < max_key_count; i++) {
             printf("%zd: %s\n", i, key_buffers[i].array.data);
@@ -132,7 +132,7 @@ int main(int argc, char** argv)
     }
 
     do_put_and_getkeyrange(session);
-    
+
     // Shutdown client connection and cleanup
     KineticClient_DestroySession(session);
     KineticClient_Shutdown(client);

--- a/src/examples/blocking_getnext_getprevious.c
+++ b/src/examples/blocking_getnext_getprevious.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -33,17 +33,17 @@ static void do_put_and_getprevious_getnext(KineticSession *session) {
         char key[] = "keyX";
         key[3] = '0' + i;
         ByteBuffer put_key_buf = ByteBuffer_MallocAndAppend(key, strlen(key));
-        
+
         uint8_t value[] = "valueX";
         value[5] = '0' + i;
         ByteBuffer put_value_buf = ByteBuffer_MallocAndAppend(value, sizeof(value));
-        
+
         /* Populate tag with SHA1 of value */
         ByteBuffer put_tag_buf = ByteBuffer_Malloc(20);
         uint8_t sha1[20];
         SHA1(put_value_buf.array.data, put_value_buf.bytesUsed, &sha1[0]);
         ByteBuffer_Append(&put_tag_buf, sha1, sizeof(sha1));
-        
+
         KineticEntry put_entry = {
             .key = put_key_buf,
             .value = put_value_buf,
@@ -153,7 +153,7 @@ int main(int argc, char** argv)
     }
 
     do_put_and_getprevious_getnext(session);
-    
+
     // Shutdown client connection and cleanup
     KineticClient_DestroySession(session);
     KineticClient_Shutdown(client);

--- a/src/examples/blocking_noop.c
+++ b/src/examples/blocking_noop.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -65,7 +65,7 @@ int main(int argc, char** argv)
     }
 
     do_noop(session);
-    
+
     // Shutdown client connection and cleanup
     KineticClient_DestroySession(session);
     KineticClient_Shutdown(client);

--- a/src/examples/blocking_put_delete.c
+++ b/src/examples/blocking_put_delete.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -34,7 +34,7 @@ static void do_put_and_delete(KineticSession *session) {
 
     const uint8_t value[] = "value\x01\x02\x03\x04";
     ByteBuffer put_value_buf = ByteBuffer_MallocAndAppend(value, sizeof(value));
-    
+
     /* Populate tag with SHA1 of value */
     ByteBuffer put_tag_buf = ByteBuffer_Malloc(20);
     uint8_t sha1[20];
@@ -105,7 +105,7 @@ int main(int argc, char** argv)
     }
 
     do_put_and_delete(session);
-    
+
     // Shutdown client connection and cleanup
     KineticClient_DestroySession(session);
     KineticClient_Shutdown(client);

--- a/src/examples/blocking_put_get.c
+++ b/src/examples/blocking_put_get.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -34,7 +34,7 @@ static void do_put_and_get(KineticSession *session) {
 
     const uint8_t value[] = "value\x01\x02\x03\x04";
     ByteBuffer put_value_buf = ByteBuffer_MallocAndAppend(value, sizeof(value));
-    
+
     /* Populate tag with SHA1 of value */
     ByteBuffer put_tag_buf = ByteBuffer_Malloc(20);
     uint8_t sha1[20];
@@ -119,7 +119,7 @@ int main(int argc, char** argv)
     }
 
     do_put_and_get(session);
-    
+
     // Shutdown client connection and cleanup
     KineticClient_DestroySession(session);
     KineticClient_Shutdown(client);

--- a/src/examples/get_key_range.c
+++ b/src/examples/get_key_range.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -31,7 +31,7 @@ int main(int argc, char** argv)
 {
     (void)argc;
     (void)argv;
-    
+
     // Initialize kinetic-c and configure sessions
     KineticSession* session;
     KineticClientConfig clientConfig = {
@@ -85,7 +85,7 @@ int main(int argc, char** argv)
         fprintf(stderr, "FAILURE: Failed retrieving key range from device!\n");
         return 3;
     }
-    
+
     if (keys.used != 2) {
         fprintf(stderr, "FAILURE: Unexpected number of keys in returned range!\n");
         return 4;

--- a/src/examples/get_nonblocking.c
+++ b/src/examples/get_nonblocking.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -143,7 +143,7 @@ int main(int argc, char** argv)
 
     ByteBuffer_Free(getValue);
     ByteBuffer_Free(getTag);
-    
+
 
     // Shutdown client connection and cleanup
     KineticClient_DestroySession(session);

--- a/src/examples/get_nonblocking.c
+++ b/src/examples/get_nonblocking.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "kinetic_client.h"
 #include "kinetic_types.h"
 #include "kinetic_semaphore.h"

--- a/src/examples/put_nonblocking.c
+++ b/src/examples/put_nonblocking.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/examples/put_nonblocking.c
+++ b/src/examples/put_nonblocking.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "kinetic_client.h"
 #include "kinetic_types.h"
 #include "kinetic_semaphore.h"

--- a/src/examples/setup_teardown.c
+++ b/src/examples/setup_teardown.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/examples/write_file_blocking.c
+++ b/src/examples/write_file_blocking.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -119,7 +119,7 @@ int main(int argc, char** argv)
 
     write_args* writeArgs = calloc(1, sizeof(write_args));
     writeArgs->session = session;
-    
+
     // Create a ByteBuffer for consuming chunks of data out of for overlapped PUTs
     writeArgs->data = ByteBuffer_Create(buf, dataLen, 0);
 

--- a/src/examples/write_file_blocking_threads.c
+++ b/src/examples/write_file_blocking_threads.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/examples/write_file_nonblocking.c
+++ b/src/examples/write_file_nonblocking.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -156,7 +156,7 @@ static int put_chunk_of_file(FileTransferProgress* transfer)
         fprintf(stderr, "Failed reading data from file!\n");
         REPORT_ERRNO(bytesRead, "read");
     }
-    
+
     return bytesRead;
 }
 
@@ -201,7 +201,7 @@ FileTransferProgress * start_file_transfer(KineticSession* session,
     pthread_mutex_init(&transferState->transferMutex, NULL);
     pthread_mutex_init(&transferState->completeMutex, NULL);
     pthread_cond_init(&transferState->completeCond, NULL);
-        
+
     // Start max overlapped PUT operations
     for (size_t i = 0; i < transferState->maxOverlappedChunks; i++) {
         put_chunk_of_file(transferState);

--- a/src/examples/write_file_nonblocking.c
+++ b/src/examples/write_file_nonblocking.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "kinetic_client.h"
 #include "kinetic_types.h"
 #include "byte_array.h"

--- a/src/lib/bus/atomic.h
+++ b/src/lib/bus/atomic.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/atomic.h
+++ b/src/lib/bus/atomic.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef ATOMIC_H
 #define ATOMIC_H
 

--- a/src/lib/bus/bus.c
+++ b/src/lib/bus/bus.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/lib/bus/bus.c
+++ b/src/lib/bus/bus.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -273,7 +273,7 @@ static boxed_msg *box_msg(struct bus *b, bus_user_msg *msg) {
     } else {
         ci->largest_wr_seq_id_seen = msg->seq_id;
     }
-    
+
     box->timeout_sec = (time_t)msg->timeout_sec;
     if (box->timeout_sec == 0) {
         box->timeout_sec = BUS_DEFAULT_TIMEOUT_SEC;
@@ -353,7 +353,7 @@ bool Bus_RegisterSocket(struct bus *b, bus_socket_t type, int fd, void *udata) {
 
     /* Spread sockets throughout the different listener threads. */
     struct listener *l = b->listeners[l_id];
-    
+
     /* Metadata about the connection. Note: This will be shared by the
      * client thread and the listener thread, but each will only modify
      * some of the fields. The client thread will free this. */
@@ -548,7 +548,7 @@ bool Bus_Shutdown(bus *b) {
 void Bus_BackpressureDelay(struct bus *b, size_t backpressure, uint8_t shift) {
     /* Push back if message bus is too busy. */
     backpressure >>= shift;
-    
+
     if (backpressure > 0) {
         BUS_LOG_SNPRINTF(b, 8, LOG_SENDER, b->udata, 64,
             "backpressure %zd", backpressure);

--- a/src/lib/bus/bus.dot
+++ b/src/lib/bus/bus.dot
@@ -14,7 +14,7 @@ digraph {
 
         // asynchronously flushes outgoing messages to drives
         sender [peripheries=2]    // many
-        
+
         drives [shape=box, peripheries=2]
         sender -> drives [label="write"]
 

--- a/src/lib/bus/bus.h
+++ b/src/lib/bus/bus.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef BUS_H
 #define BUS_H
 

--- a/src/lib/bus/bus.h
+++ b/src/lib/bus/bus.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -25,7 +25,7 @@
 bool Bus_Init(bus_config *config, struct bus_result *res);
 
 /** Send a request. Blocks until the request has been transmitted.
- * 
+ *
  * Assumes the FD has been registered with Bus_register_socket;
  * sending to an unregistered socket is an error.
  *
@@ -40,7 +40,7 @@ bool Bus_SendRequest(struct bus *b, bus_user_msg *msg);
 
 /** Register a socket connected to an endpoint, and data that will be passed
  * to all interactions on that socket.
- * 
+ *
  * The socket will have request -> response messages with timeouts, as
  * well as unsolicited status messages.
  *

--- a/src/lib/bus/bus_example.c
+++ b/src/lib/bus/bus_example.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/src/lib/bus/bus_example.c
+++ b/src/lib/bus/bus_example.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -73,7 +73,7 @@ typedef struct {
     size_t sent_msgs;
     size_t completed_deliveries;
     size_t max_seq_id;
-    
+
     socket_info *info[MAX_SOCKETS];
 } example_state;
 
@@ -100,7 +100,7 @@ static bus_sink_cb_res_t reset_transfer(socket_info *si) {
     bus_sink_cb_res_t res = { /* prime pump with header size */
         .next_read = sizeof(prot_header_t),
     };
-    
+
     si->state = STATE_AWAITING_HEADER;
     si->used = 0;
     return res;
@@ -173,7 +173,7 @@ static bus_sink_cb_res_t sink_cb(uint8_t *read_buf,
             assert(false);
             return reset_transfer(si);
         }
-        
+
         break;
     }
     case STATE_AWAITING_BODY:
@@ -327,7 +327,7 @@ static void parse_args(int argc, char **argv, example_state *s) {
             fprintf(stderr, "illegal option: -- %c\n", a);
             usage();
         }
-    } 
+    }
 
     if (s->port_low == 0) { s->port_low = s->port_high; }
     if (s->port_high == 0) { s->port_high = s->port_low; }
@@ -497,7 +497,7 @@ static void run_bus(example_state *s, struct bus *b) {
                 .cb = completion_cb,
                 .udata = s->info[cur_socket_i],
             };
-            
+
             s->sent_msgs++;
             payload_size++;
             if (!Bus_SendRequest(b, &msg)) {
@@ -508,7 +508,7 @@ static void run_bus(example_state *s, struct bus *b) {
                     loop_flag = false;
                 }
             }
-            
+
             cur_socket_i++;
             if (cur_socket_i == s->sockets_used) {
                 cur_socket_i = 0;

--- a/src/lib/bus/bus_internal_types.h
+++ b/src/lib/bus/bus_internal_types.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef BUS_INTERNAL_TYPES_H
 #define BUS_INTERNAL_TYPES_H
 

--- a/src/lib/bus/bus_internal_types.h
+++ b/src/lib/bus/bus_internal_types.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/bus_inward.h
+++ b/src/lib/bus/bus_inward.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef BUS_INWARD_H
 #define BUS_INWARD_H
 

--- a/src/lib/bus/bus_inward.h
+++ b/src/lib/bus/bus_inward.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/bus_poll.c
+++ b/src/lib/bus/bus_poll.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "bus_poll.h"
 #include "syscall.h"
 #include "listener.h"

--- a/src/lib/bus/bus_poll.c
+++ b/src/lib/bus/bus_poll.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/bus_poll.h
+++ b/src/lib/bus/bus_poll.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/bus_poll.h
+++ b/src/lib/bus/bus_poll.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef BUS_POLL_H
 #define BUS_POLL_H
 

--- a/src/lib/bus/bus_ssl.c
+++ b/src/lib/bus/bus_ssl.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include <poll.h>
 #include <assert.h>
 

--- a/src/lib/bus/bus_ssl.c
+++ b/src/lib/bus/bus_ssl.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -131,7 +131,7 @@ static bool do_blocking_connection(struct bus *b, SSL *ssl, int fd) {
     struct pollfd fds[1];
     fds[0].fd = fd;
     fds[0].events = POLLOUT;
-    
+
     bool connected = false;
     size_t elapsed = 0;
 
@@ -165,12 +165,12 @@ static bool do_blocking_connection(struct bus *b, SSL *ssl, int fd) {
                         BUS_LOG(b, 4, LOG_SOCKET_REGISTERED, "WANT_WRITE", b->udata);
                         fds[0].events = POLLOUT;
                         break;
-                        
+
                     case SSL_ERROR_WANT_READ:
                         BUS_LOG(b, 4, LOG_SOCKET_REGISTERED, "WANT_READ", b->udata);
                         fds[0].events = POLLIN;
                         break;
-                        
+
                     case SSL_ERROR_SYSCALL:
                     {
                         if (Util_IsResumableIOError(errno)) {
@@ -218,6 +218,6 @@ static bool do_blocking_connection(struct bus *b, SSL *ssl, int fd) {
             }
         }
     }
-    
+
     return connected;
 }

--- a/src/lib/bus/bus_ssl.h
+++ b/src/lib/bus/bus_ssl.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef BUS_SSL_H
 #define BUS_SSL_H
 

--- a/src/lib/bus/bus_ssl.h
+++ b/src/lib/bus/bus_ssl.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/bus_types.h
+++ b/src/lib/bus/bus_types.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef BUS_TYPES_H
 #define BUS_TYPES_H
 

--- a/src/lib/bus/bus_types.h
+++ b/src/lib/bus/bus_types.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -139,11 +139,11 @@ typedef struct {
         struct {
             uintptr_t opaque_error_id;
         } error;
-    } u;    
+    } u;
 } bus_unpack_cb_res_t;
 
 /* Unpack a message that has been gradually accumulated via bus_sink_cb.
- * 
+ *
  * Note that the udata pointer is socket-specific, NOT client-specific. */
 typedef bus_unpack_cb_res_t (bus_unpack_cb)(void *msg, void *socket_udata);
 
@@ -170,7 +170,7 @@ typedef struct bus_config {
 
     int log_level;
     bus_log_cb *log_cb;         /* optional */
-    
+
     void *bus_udata;
 } bus_config;
 

--- a/src/lib/bus/echosrv.c
+++ b/src/lib/bus/echosrv.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/src/lib/bus/echosrv.c
+++ b/src/lib/bus/echosrv.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -95,7 +95,7 @@ static void usage(void) {
 
 static void parse_args(int argc, char **argv, config *cfg) {
     int a = 0;
-    
+
     while ((a = getopt(argc, argv, "l:h:v")) != -1) {
         switch (a) {
         case 'l':               /* low port */
@@ -111,7 +111,7 @@ static void parse_args(int argc, char **argv, config *cfg) {
             fprintf(stderr, "illegal option: -- %c\n", a);
             usage();
         }
-    } 
+    }
 
     if (cfg->port_low == 0) { cfg->port_low = cfg->port_high; }
     if (cfg->port_high == 0) { cfg->port_high = cfg->port_low; }
@@ -123,7 +123,7 @@ int main(int argc, char **argv) {
     config cfg;
     memset(&cfg, 0, sizeof(cfg));
     parse_args(argc, argv, &cfg);
-        
+
     init_polling(&cfg);
     open_ports(&cfg);
     listen_loop_poll(&cfg);
@@ -133,7 +133,7 @@ int main(int argc, char **argv) {
 
 static void init_polling(config *cfg) {
     cfg->port_count = cfg->port_high - cfg->port_low + 1;
-    
+
     size_t accept_fds_sz = cfg->port_count * sizeof(struct pollfd);
     struct pollfd *accept_fds = malloc(accept_fds_sz);
     assert(accept_fds);
@@ -208,7 +208,7 @@ static void listen_loop_poll(config *cfg) {
             tick_handler(cfg);
             cfg->last_second = tv.tv_sec;
         }
-        
+
         int accept_delay = 0;
         int client_delay = 0;
 
@@ -224,7 +224,7 @@ static void listen_loop_poll(config *cfg) {
             /* Listen for incoming connections */
             int res = poll(cfg->accept_fds, cfg->port_count, accept_delay);
             LOG((res == 0 ? 6 : 3), "accept poll res %d\n", res);
-            
+
             if (res == -1) {
                 if (Util_IsResumableIOError(errno)) {
                     errno = 0;
@@ -333,7 +333,7 @@ static void handle_client_io(config *cfg, int available) {
         struct pollfd *fd = &cfg->client_fds[i];
 
         LOG(4, "fd[%d]->events 0x%08x ==> revents: 0x%08x\n", i, fd->events, fd->revents);
-        
+
         if ((fd->revents & POLLERR) || (fd->revents & POLLHUP)) {
             LOG(3, "Disconnecting client %d\n", fd->fd);
             disconnect_client(cfg, fd->fd);

--- a/src/lib/bus/listener.c
+++ b/src/lib/bus/listener.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>

--- a/src/lib/bus/listener.c
+++ b/src/lib/bus/listener.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -224,7 +224,7 @@ void Listener_Free(struct listener *l) {
 
         if (l->read_buf) {
             free(l->read_buf);
-        }                
+        }
 
         syscall_close(l->commit_pipe);
         syscall_close(l->incoming_msg_pipe);

--- a/src/lib/bus/listener.h
+++ b/src/lib/bus/listener.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef LISTENER_H
 #define LISTENER_H
 

--- a/src/lib/bus/listener.h
+++ b/src/lib/bus/listener.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/listener_cmd.c
+++ b/src/lib/bus/listener_cmd.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include <unistd.h>
 #include <err.h>
 #include <assert.h>

--- a/src/lib/bus/listener_cmd.c
+++ b/src/lib/bus/listener_cmd.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -53,7 +53,7 @@ void ListenerCmd_NotifyCaller(listener *l, int fd) {
         BUS_LOG_SNPRINTF(b, 6, LOG_LISTENER, b->udata, 128,
             "NotifyCaller on %d with backpressure %u",
             fd, backpressure);;
-        
+
         ssize_t wres = syscall_write(fd, reply_buf, sizeof(reply_buf));
         if (wres == sizeof(reply_buf)) { break; }
         if (wres == -1) {
@@ -243,7 +243,7 @@ static void remove_socket(listener *l, int fd, int notify_fd) {
 
                 /* The node is now at the end of the array. */
             }
-            
+
             l->tracked_fds--;
             if (!is_active) { l->inactive_fds--; }
         }
@@ -255,7 +255,7 @@ static void remove_socket(listener *l, int fd, int notify_fd) {
 static void hold_response(listener *l, int fd, int64_t seq_id,
         int16_t timeout_sec, int notify_fd) {
     struct bus *b = l->bus;
-    
+
     BUS_LOG_SNPRINTF(b, 5, LOG_LISTENER, b->udata, 128,
         "hold_response <fd:%d, seq_id:%lld>", fd, (long long)seq_id);
 
@@ -313,7 +313,7 @@ static void expect_response(listener *l, struct boxed_msg *box) {
         } else if (info->u.hold.error != RX_ERROR_NONE) {
             BUS_LOG_SNPRINTF(b, 3, LOG_LISTENER, b->udata, 256,
                 "info %p (%d) with <box:%p, fd:%d, seq_id:%lld> has error %d",
-                (void *)info, info->id, 
+                (void *)info, info->id,
                 (void *)box, info->u.hold.fd, (long long)info->u.hold.seq_id, info->u.hold.error);
             rx_error_t error = info->u.hold.error;
             bus_unpack_cb_res_t result = info->u.hold.result;
@@ -337,7 +337,7 @@ static void expect_response(listener *l, struct boxed_msg *box) {
     } else if (info && info->state == RIS_EXPECT) {
         /* Multiple identical EXPECTs should never happen, outside of
          * memory corruption in the queue. */
-        assert(false);          
+        assert(false);
     } else {
         /* should never happen; just drop the message */
     }

--- a/src/lib/bus/listener_cmd.h
+++ b/src/lib/bus/listener_cmd.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/listener_cmd.h
+++ b/src/lib/bus/listener_cmd.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef LISTENER_CMD_H
 #define LISTENER_CMD_H
 

--- a/src/lib/bus/listener_cmd_internal.h
+++ b/src/lib/bus/listener_cmd_internal.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef LISTENER_CMD_INTERNAL_H
 #define LISTENER_CMD_INTERNAL_H
 

--- a/src/lib/bus/listener_cmd_internal.h
+++ b/src/lib/bus/listener_cmd_internal.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/listener_helper.c
+++ b/src/lib/bus/listener_helper.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "listener_helper.h"
 #include "listener_task.h"
 #include "syscall.h"

--- a/src/lib/bus/listener_helper.c
+++ b/src/lib/bus/listener_helper.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -67,7 +67,7 @@ listener_msg *ListenerHelper_GetFreeMsg(listener *l) {
 bool ListenerHelper_PushMessage(struct listener *l, listener_msg *msg, int *reply_fd) {
     struct bus *b = l->bus;
     BUS_ASSERT(b, b->udata, msg);
-  
+
     #ifndef TEST
     uint8_t msg_buf[sizeof(uint8_t)];
     #endif
@@ -111,7 +111,7 @@ rx_info_t *ListenerHelper_GetFreeRXInfo(struct listener *l) {
             BUS_LOG_SNPRINTF(b, 5, LOG_LISTENER, b->udata, 128,
                 "rx_info_max_used <- %d", head->id);
             l->rx_info_max_used = head->id;
-            BUS_ASSERT(b, b->udata, l->rx_info_max_used < MAX_PENDING_MESSAGES); 
+            BUS_ASSERT(b, b->udata, l->rx_info_max_used < MAX_PENDING_MESSAGES);
         }
 
         BUS_LOG_SNPRINTF(b, 5, LOG_LISTENER, b->udata, 128,
@@ -123,7 +123,7 @@ rx_info_t *ListenerHelper_GetFreeRXInfo(struct listener *l) {
 
 rx_info_t *ListenerHelper_FindInfoBySequenceID(listener *l,
         int fd, int64_t seq_id) {
-    struct bus *b = l->bus;    
+    struct bus *b = l->bus;
     for (int i = 0; i <= l->rx_info_max_used; i++) {
         rx_info_t *info = &l->rx_info[i];
 
@@ -158,7 +158,7 @@ rx_info_t *ListenerHelper_FindInfoBySequenceID(listener *l,
 
     if (b->log_level > 5 || 0) {
         BUS_LOG_SNPRINTF(b, 0, LOG_LISTENER, b->udata, 64,
-            "==== Could not find <fd:%d, seq_id:%lld>, dumping table ====\n", 
+            "==== Could not find <fd:%d, seq_id:%lld>, dumping table ====\n",
             fd, (long long)seq_id);
         ListenerTask_DumpRXInfoTable(l);
     }

--- a/src/lib/bus/listener_helper.h
+++ b/src/lib/bus/listener_helper.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/listener_helper.h
+++ b/src/lib/bus/listener_helper.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef LISTENER_HELPER_H
 #define LISTENER_HELPER_H
 

--- a/src/lib/bus/listener_internal.h
+++ b/src/lib/bus/listener_internal.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/listener_internal.h
+++ b/src/lib/bus/listener_internal.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef LISTENER_INTERNAL_H
 #define LISTENER_INTERNAL_H
 

--- a/src/lib/bus/listener_internal_types.h
+++ b/src/lib/bus/listener_internal_types.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef LISTENER_INTERNAL_TYPES_H
 #define LISTENER_INTERNAL_TYPES_H
 

--- a/src/lib/bus/listener_internal_types.h
+++ b/src/lib/bus/listener_internal_types.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -50,7 +50,7 @@ typedef struct listener_msg {
     MSG_TYPE type;
     struct listener_msg *next;
     int pipes[2];
-    
+
     union {                     /* keyed by .type */
         struct {
             connection_info *info;
@@ -163,7 +163,7 @@ typedef struct listener {
     uint16_t inactive_fds;
 
     /** Tracked file descriptors, for polling.
-     * 
+     *
      * fds[INCOMING_MSG_PIPE_ID (0)] is the incoming_msg_pipe, so the
      * listener's poll is awakened by incoming commands. fds[1] through
      * fds[l->tracked_fds - l->inactive_fds] are the file descriptors

--- a/src/lib/bus/listener_io.c
+++ b/src/lib/bus/listener_io.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "listener_io.h"
 #include "listener_helper.h"
 

--- a/src/lib/bus/listener_io.c
+++ b/src/lib/bus/listener_io.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -43,13 +43,13 @@ void ListenerIO_AttemptRecv(listener *l, int available) {
     struct bus *b = l->bus;
     int read_from = 0;
     BUS_LOG(b, 3, LOG_LISTENER, "attempting receive", b->udata);
-    
+
     for (int i = 0; i < l->tracked_fds; i++) {
         if (read_from == available) { break; }
         struct pollfd *fd = &l->fds[i + INCOMING_MSG_PIPE];
         connection_info *ci = l->fd_info[i];
         BUS_ASSERT(b, b->udata, ci->fd == fd->fd);
-        
+
         BUS_LOG_SNPRINTF(b, 1, LOG_LISTENER, b->udata, 64,
             "poll: l->fds[%d]->revents: 0x%04x",  // NOCOMMIT
             i + INCOMING_MSG_PIPE, fd->revents);
@@ -72,7 +72,7 @@ void ListenerIO_AttemptRecv(listener *l, int available) {
                     "reading %zd bytes from socket (buf is %zd)",
                     ci->to_read_size, l->read_buf_size);
                 BUS_ASSERT(b, b->udata, l->read_buf_size >= to_read);
-                
+
                 switch (ci->type) {
                 case BUS_SOCKET_PLAIN:
                     cur_read = socket_read_plain(b, l, i, ci);
@@ -107,9 +107,9 @@ void ListenerIO_AttemptRecv(listener *l, int available) {
          * or skipping any individual file descriptors. */
         move_errored_active_sockets_to_end(l);
         l->error_occured = false;
-    }        
+    }
 }
-    
+
 static ssize_t socket_read_plain(struct bus *b, listener *l, int pfd_i, connection_info *ci) {
     ssize_t accum = 0;
     while (ci->to_read_size > 0) {
@@ -131,7 +131,7 @@ static ssize_t socket_read_plain(struct bus *b, listener *l, int pfd_i, connecti
                 return -1;
             }
         }
-        
+
         if (size > 0) {
             BUS_LOG_SNPRINTF(b, 5, LOG_LISTENER, b->udata, 64,
                 "read: %zd", size);
@@ -163,7 +163,7 @@ static ssize_t socket_read_ssl(struct bus *b, listener *l, int pfd_i, connection
     while (ci->to_read_size > 0) {
         // ssize_t pending = SSL_pending(ci->ssl);
         ssize_t size = (ssize_t)syscall_SSL_read(ci->ssl, l->read_buf, ci->to_read_size);
-        
+
         if (size == -1) {
             int reason = syscall_SSL_get_error(ci->ssl, size);
             switch (reason) {
@@ -171,7 +171,7 @@ static ssize_t socket_read_ssl(struct bus *b, listener *l, int pfd_i, connection
                 BUS_LOG_SNPRINTF(b, 3, LOG_LISTENER, b->udata, 64,
                     "SSL_read fd %d: WANT_READ", ci->fd);
                 return accum;
-                
+
             case SSL_ERROR_WANT_WRITE:
                 BUS_ASSERT(b, b->udata, false);
 
@@ -199,7 +199,7 @@ static ssize_t socket_read_ssl(struct bus *b, listener *l, int pfd_i, connection
                 set_error_for_socket(l, pfd_i, ci->fd, RX_ERROR_POLLHUP);
                 return -1;
             }
-            
+
             default:
                 print_SSL_error(b, ci, 1, "SSL_ERROR UNKNOWN");
                 set_error_for_socket(l, pfd_i, ci->fd, RX_ERROR_READ_FAILURE);
@@ -222,7 +222,7 @@ static bool sink_socket_read(struct bus *b,
         listener *l, connection_info *ci, ssize_t size) {
     BUS_LOG_SNPRINTF(b, 3, LOG_LISTENER, b->udata, 64,
         "read %zd bytes, calling sink CB", size);
-    
+
 #if DUMP_READ
     printf("\n");
     for (int i = 0; i < size; i++) {
@@ -231,7 +231,7 @@ static bool sink_socket_read(struct bus *b,
     }
     printf("\n\n");
 #endif
-    
+
     bus_sink_cb_res_t sres = b->sink_cb(l->read_buf, size, ci->udata);
     if (sres.full_msg_buffer) {
         BUS_LOG(b, 3, LOG_LISTENER, "calling unpack CB", b->udata);
@@ -241,12 +241,12 @@ static bool sink_socket_read(struct bus *b,
             ures.ok, (long long)ures.u.success.seq_id);
         process_unpacked_message(l, ci, ures);
     }
-    
+
     ci->to_read_size = sres.next_read;
-    
+
     BUS_LOG_SNPRINTF(b, 3, LOG_LISTENER, b->udata, 64,
         "expecting next read to have %zd bytes", ci->to_read_size);
-    
+
     /* Grow read buffer if necessary. */
     if (ci->to_read_size > l->read_buf_size) {
         if (!ListenerTask_GrowReadBuf(l, ci->to_read_size)) {

--- a/src/lib/bus/listener_io.h
+++ b/src/lib/bus/listener_io.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef LISTENER_IO_H
 #define LISTENER_IO_H
 

--- a/src/lib/bus/listener_io.h
+++ b/src/lib/bus/listener_io.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/listener_task.c
+++ b/src/lib/bus/listener_task.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "listener_task.h"
 #include "listener_task_internal.h"
 #include "util.h"

--- a/src/lib/bus/listener_task.c
+++ b/src/lib/bus/listener_task.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -99,12 +99,12 @@ void *ListenerTask_MainLoop(void *arg) {
     /* (This will always be true, except when testing.) */
     if (self->shutdown_notify_fd != LISTENER_NO_FD) {
         BUS_LOG(b, 3, LOG_LISTENER, "shutting down", b->udata);
-        
+
         if (self->tracked_fds > 0) {
             BUS_LOG_SNPRINTF(b, 0, LOG_LISTENER, b->udata, 64,
                 "%d connections still open!", self->tracked_fds);
         }
-        
+
         ListenerCmd_NotifyCaller(self, self->shutdown_notify_fd);
         self->shutdown_notify_fd = LISTENER_SHUTDOWN_COMPLETE_FD;
     }
@@ -127,7 +127,7 @@ static void tick_handler(listener *l) {
             printf(" -- msg %d: type %d\n", i, l->msgs[i].type);
         }
     }
-    
+
     if (b->log_level > 5 || 0) { ListenerTask_DumpRXInfoTable(l); }
 
     for (int i = 0; i <= l->rx_info_max_used; i++) {
@@ -193,8 +193,8 @@ static void tick_handler(listener *l) {
                     "notifying of rx failure -- timeout (info %p) -- "
                     "<fd:%d, seq_id:%lld>, from time (queued:%ld.%ld) to (sent:%ld.%ld) to (now:%ld.%ld)",
                     (void*)info, box->fd, (long long)box->out_seq_id,
-                    (long)box->tv_send_start.tv_sec, (long)box->tv_send_start.tv_usec, 
-                    (long)box->tv_send_done.tv_sec, (long)box->tv_send_done.tv_usec, 
+                    (long)box->tv_send_start.tv_sec, (long)box->tv_send_start.tv_usec,
+                    (long)box->tv_send_done.tv_sec, (long)box->tv_send_done.tv_usec,
                     (long)cur.tv_sec, (long)cur.tv_usec);
                 (void)box;
 
@@ -218,7 +218,7 @@ static void tick_handler(listener *l) {
 void ListenerTask_DumpRXInfoTable(listener *l) {
     for (int i = 0; i <= l->rx_info_max_used; i++) {
         rx_info_t *info = &l->rx_info[i];
-        
+
         printf(" -- state: %d, info[%d]: timeout %ld",
             info->state, info->id, info->timeout_sec);
         switch (l->rx_info[i].state) {
@@ -321,10 +321,10 @@ void ListenerTask_NotifyMessageFailure(listener *l,
     struct bus *b = l->bus;
     BUS_ASSERT(b, b->udata, info->state == RIS_EXPECT);
     BUS_ASSERT(b, b->udata, info->u.expect.box);
-    
+
     BUS_ASSERT(b, b->udata, status != BUS_SEND_UNDEFINED);
     info->u.expect.box->result.status = status;
-    
+
     boxed_msg *box = info->u.expect.box;
     info->u.expect.box = NULL;
     BUS_LOG_SNPRINTF(b, 3, LOG_MEMORY, b->udata, 128,
@@ -383,7 +383,7 @@ void ListenerTask_ReleaseRXInfo(struct listener *l, rx_info_t *info) {
                 } else {
                     BUS_LOG_SNPRINTF(b, 0, LOG_LISTENER, b->udata, 128,
                         "LEAKING RESULT %p", (void *)&info->u.hold.result);
-                }                
+                }
             }
         }
         break;
@@ -415,7 +415,7 @@ void ListenerTask_ReleaseRXInfo(struct listener *l, rx_info_t *info) {
             l->rx_info_max_used--;
             if (l->rx_info_max_used == 0) { break; }
         }
-        BUS_ASSERT(b, b->udata, l->rx_info_max_used < MAX_PENDING_MESSAGES); 
+        BUS_ASSERT(b, b->udata, l->rx_info_max_used < MAX_PENDING_MESSAGES);
     }
 
     l->rx_info_in_use--;
@@ -441,7 +441,7 @@ void ListenerTask_ReleaseMsg(struct listener *l, listener_msg *msg) {
         }
     }
 }
- 
+
 bool ListenerTask_GrowReadBuf(listener *l, size_t nsize) {
     if (nsize < l->read_buf_size) { return true; }
 
@@ -527,7 +527,7 @@ static void observe_backpressure(listener *l, size_t backpressure) {
 
 uint16_t ListenerTask_GetBackpressure(struct listener *l) {
     uint16_t msg_fill_pressure = 0;
-    
+
     if (l->msgs_in_use < 0.25 * MAX_QUEUE_MESSAGES) {
         msg_fill_pressure = 0;
     } else if (l->msgs_in_use < 0.5 * MAX_QUEUE_MESSAGES) {
@@ -548,7 +548,7 @@ uint16_t ListenerTask_GetBackpressure(struct listener *l) {
     } else {
         rx_info_fill_pressure = RX_INFO_BP_3QTR * l->rx_info_in_use;
     }
-    
+
     uint16_t threadpool_fill_pressure = THREADPOOL_BP * l->upstream_backpressure;
 
     struct bus *b = l->bus;

--- a/src/lib/bus/listener_task.h
+++ b/src/lib/bus/listener_task.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/listener_task.h
+++ b/src/lib/bus/listener_task.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef LISTENER_TASK_H
 #define LISTENER_TASK_H
 

--- a/src/lib/bus/listener_task_internal.h
+++ b/src/lib/bus/listener_task_internal.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef LISTENER_TASK_INTERNAL_H
 #define LISTENER_TASK_INTERNAL_H
 

--- a/src/lib/bus/listener_task_internal.h
+++ b/src/lib/bus/listener_task_internal.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/send.c
+++ b/src/lib/bus/send.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>

--- a/src/lib/bus/send.c
+++ b/src/lib/bus/send.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -65,7 +65,7 @@ bool Send_DoBlockingSend(bus *b, boxed_msg *box) {
         "doing blocking send of box %p, with <fd:%d, seq_id %lld>, msg[%zd]: %p",
         (void *)box, box->fd, (long long)box->out_seq_id,
         box->out_msg_size, (void *)box->out_msg);
-    
+
     int timeout_msec = box->timeout_sec * 1000;
 
 #ifndef TEST
@@ -211,7 +211,7 @@ void Send_HandleFailure(struct bus *b, boxed_msg *box, bus_send_status_t status)
     box->result = (bus_msg_result_t){
         .status = status,
     };
-    
+
     #ifndef TEST
     size_t backpressure = 0;
     #endif

--- a/src/lib/bus/send.h
+++ b/src/lib/bus/send.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef SEND_H
 #define SEND_H
 

--- a/src/lib/bus/send.h
+++ b/src/lib/bus/send.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/send_helper.c
+++ b/src/lib/bus/send_helper.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "send_helper.h"
 #include "send_internal.h"
 

--- a/src/lib/bus/send_helper.c
+++ b/src/lib/bus/send_helper.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -97,7 +97,7 @@ static ssize_t write_plain(struct bus *b, boxed_msg *box) {
     size_t msg_size = box->out_msg_size;
     size_t sent_size = box->out_sent_size;
     size_t rem = msg_size - sent_size;
-    
+
     BUS_LOG_SNPRINTF(b, 10, LOG_SENDER, b->udata, 64,
         "write %p to %d, %zd bytes",
         (void*)&msg[sent_size], fd, rem);
@@ -152,13 +152,13 @@ static ssize_t write_ssl(struct bus *b, boxed_msg *box, SSL *ssl) {
                 BUS_LOG_SNPRINTF(b, 3, LOG_SENDER, b->udata, 64,
                     "SSL_write: socket %d: WANT_WRITE", fd);
                 return 0;
-                
+
             case SSL_ERROR_WANT_READ:
                 BUS_LOG_SNPRINTF(b, 0, LOG_SENDER, b->udata, 64,
                     "SSL_write: socket %d: WANT_READ", fd);
                 assert(false);  // shouldn't get this; we're writing.
                 break;
-                
+
             case SSL_ERROR_SYSCALL:
             {
                 if (Util_IsResumableIOError(errno)) {
@@ -172,7 +172,7 @@ static ssize_t write_ssl(struct bus *b, boxed_msg *box, SSL *ssl) {
                     BUS_LOG_SNPRINTF(b, 1, LOG_SENDER, b->udata, 64,
                         "SSL_write on fd %d: SSL_ERROR_SYSCALL -- %s",
                         fd, strerror(errno));
-                    errno = 0;                    
+                    errno = 0;
                     return -1;
                 }
             }
@@ -189,7 +189,7 @@ static ssize_t write_ssl(struct bus *b, boxed_msg *box, SSL *ssl) {
                         "SSL_write error: %s",
                         ERR_error_string(e, NULL));
                 }
-                return -1;                
+                return -1;
             default:
             {
                 BUS_LOG_SNPRINTF(b, 1, LOG_SENDER, b->udata, 64,
@@ -215,7 +215,7 @@ static bool enqueue_EXPECT_message_to_listener(bus *b, boxed_msg *box) {
     BUS_LOG_SNPRINTF(b, 3, LOG_SENDER, b->udata, 128,
         "telling listener to EXPECT sent response, with box %p, seq_id %lld",
         (void *)box, (long long)box->out_seq_id);
-    
+
     if (box->result.status == BUS_SEND_UNDEFINED) {
         box->result.status = BUS_SEND_REQUEST_COMPLETE;
     }

--- a/src/lib/bus/send_helper.h
+++ b/src/lib/bus/send_helper.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/send_helper.h
+++ b/src/lib/bus/send_helper.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef SEND_HELPER_H
 #define SEND_HELPER_H
 

--- a/src/lib/bus/send_internal.h
+++ b/src/lib/bus/send_internal.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef SEND_INTERNAL_H
 #define SEND_INTERNAL_H
 

--- a/src/lib/bus/send_internal.h
+++ b/src/lib/bus/send_internal.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/syscall.c
+++ b/src/lib/bus/syscall.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/syscall.c
+++ b/src/lib/bus/syscall.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "syscall.h"
 
 #include <unistd.h>

--- a/src/lib/bus/syscall.h
+++ b/src/lib/bus/syscall.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef SYSCALL_H
 #define SYSCALL_H
 

--- a/src/lib/bus/syscall.h
+++ b/src/lib/bus/syscall.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/util.c
+++ b/src/lib/bus/util.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include <stdbool.h>
 #include <errno.h>
 #include <time.h>

--- a/src/lib/bus/util.c
+++ b/src/lib/bus/util.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/util.h
+++ b/src/lib/bus/util.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef UTIL_H
 #define UTIL_H
 

--- a/src/lib/bus/util.h
+++ b/src/lib/bus/util.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/yacht.c
+++ b/src/lib/bus/yacht.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/yacht.h
+++ b/src/lib/bus/yacht.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef YACHT_H
 #define YACHT_H
 

--- a/src/lib/bus/yacht.h
+++ b/src/lib/bus/yacht.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/yacht_internals.h
+++ b/src/lib/bus/yacht_internals.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/bus/yacht_internals.h
+++ b/src/lib/bus/yacht_internals.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef YACHT_INTERNALS_H
 #define YACHT_INTERNALS_H
 

--- a/src/lib/byte_array.c
+++ b/src/lib/byte_array.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "byte_array.h"
 #include <assert.h>
 #include <string.h>

--- a/src/lib/byte_array.c
+++ b/src/lib/byte_array.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_acl.c
+++ b/src/lib/kinetic_acl.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include <string.h>
 #include <stdio.h>
 #include <fcntl.h>

--- a/src/lib/kinetic_acl.c
+++ b/src/lib/kinetic_acl.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -73,7 +73,7 @@ KineticACL_LoadFromFile(const char *path, struct ACL **instance)
     if (path == NULL || instance == NULL) {
         return ACL_ERROR_NULL;
     }
-    
+
     int fd = open(path, O_RDONLY);
     if (fd == -1) {
 #ifndef TEST
@@ -176,7 +176,7 @@ static KineticACLLoadResult acl_of_string(const char *buf, size_t buf_size, stru
 
 cleanup:
     if (tokener) { json_tokener_free(tokener); }
-    
+
     if (res == ACL_END_OF_STREAM || res == ACL_OK) {
         if (acl_group && acl_group->ACL_count == 0) {
             LOG2("Failed to read any JSON objects");
@@ -206,9 +206,9 @@ static KineticACLLoadResult read_next_ACL(const char *buf, size_t buf_size,
             return ACL_ERROR_BAD_JSON;
         }
     }
-    
+
     *new_offset = tokener->char_offset;
-    
+
     KineticACLLoadResult res = ACL_ERROR_MEMORY;
     Com__Seagate__Kinetic__Proto__Command__Security__ACL *acl = NULL;
     uint8_t *data = NULL;
@@ -221,12 +221,12 @@ static KineticACLLoadResult read_next_ACL(const char *buf, size_t buf_size,
         res = ACL_ERROR_MISSING_FIELD;
         goto cleanup;
     }
-    
+
     size_t alloc_sz = sizeof(*acl);
     acl = calloc(1, alloc_sz);
     if (acl == NULL) { goto cleanup; }
 
-    com__seagate__kinetic__proto__command__security__acl__init(acl);    
+    com__seagate__kinetic__proto__command__security__acl__init(acl);
 
     /* Copy fields */
     if (json_object_object_get_ex(obj, "identity", &val)) {
@@ -235,7 +235,7 @@ static KineticACLLoadResult read_next_ACL(const char *buf, size_t buf_size,
     } else {
         acl->has_identity = false;
     }
-    
+
     if (json_object_object_get_ex(obj, "key", &val)) {
         const char *key = json_object_get_string(val);
         size_t len = strlen(key);
@@ -252,7 +252,7 @@ static KineticACLLoadResult read_next_ACL(const char *buf, size_t buf_size,
         data = NULL;
         acl->has_key = true;
     }
-    
+
     if (json_object_object_get_ex(obj, "HMACAlgorithm", &val)) {
         const char *hmac = json_object_get_string(val);
         if (0 != strcmp(hmac, "HmacSHA1")) {
@@ -262,13 +262,13 @@ static KineticACLLoadResult read_next_ACL(const char *buf, size_t buf_size,
             // acl->key->type is already set to HMAC_SHA1.
         }
     }
-    
+
     struct json_object *scopes = NULL;
     if (json_object_object_get_ex(obj, "scope", &scopes)) {
         res = unpack_scopes(acl, scope_count, scopes);
         if (res != ACL_OK) { goto cleanup; }
     }
-    
+
     /* Decrement JSON object refcount, freeing it. */
     json_object_put(obj);
     *instance = acl;
@@ -300,7 +300,7 @@ static KineticACLLoadResult unpack_scopes(Com__Seagate__Kinetic__Proto__Command_
             scope = calloc(1, sizeof(*scope));
             if (scope == NULL) { goto cleanup; }
             com__seagate__kinetic__proto__command__security__acl__scope__init(scope);
-    
+
             struct json_object *val = NULL;
             if (json_object_object_get_ex(cur_scope, "offset", &val)) {
                 scope->offset = json_object_get_int64(val);
@@ -390,7 +390,7 @@ void KineticACL_Print(FILE *f, struct ACL *ACLs)
     }
 
     fprintf(f, "ACLs [%zd]:\n", ACLs->ACL_count);
-    
+
     for (size_t ai = 0; ai < ACLs->ACL_count; ai++) {
         Com__Seagate__Kinetic__Proto__Command__Security__ACL *acl = ACLs->ACLs[ai];
         if (acl == NULL) { continue; }
@@ -406,7 +406,7 @@ void KineticACL_Print(FILE *f, struct ACL *ACLs)
         }
 
         fprintf(f, "  scopes: (%zd)\n", acl->n_scope);
-        
+
         for (size_t si = 0; si < acl->n_scope; si++) {
             Com__Seagate__Kinetic__Proto__Command__Security__ACL__Scope *scope = acl->scope[si];
             if (si > 0) { fprintf(f, "\n"); }
@@ -443,7 +443,7 @@ void KineticACL_Free(struct ACL *ACLs) {
 
                     if (scope->n_permission > 0) {
                         free(scope->permission);
-                    }                    
+                    }
                     free(scope);
                 }
                 free(acl->scope);

--- a/src/lib/kinetic_acl.h
+++ b/src/lib/kinetic_acl.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef KINETIC_ACL_H
 #define KINETIC_ACL_H
 

--- a/src/lib/kinetic_acl.h
+++ b/src/lib/kinetic_acl.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_acl_types.h
+++ b/src/lib/kinetic_acl_types.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_acl_types.h
+++ b/src/lib/kinetic_acl_types.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef KINETIC_ACL_TYPES_H
 #define KINETIC_ACL_TYPES_H
 

--- a/src/lib/kinetic_admin_client.c
+++ b/src/lib/kinetic_admin_client.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -277,12 +277,12 @@ KineticStatus KineticAdminClient_UpdateFirmware(KineticSession * const session,
 
     KineticOperation* operation = KineticAllocator_NewOperation(session);
     if (operation == NULL) {return KINETIC_STATUS_MEMORY_ERROR;}
-    
+
     KineticStatus status = KineticBuilder_BuildUpdateFirmware(operation, fw_path);
     if (status != KINETIC_STATUS_SUCCESS) {
         return status;
     }
-    
+
     return KineticController_ExecuteOperation(operation, NULL);
 }
 

--- a/src/lib/kinetic_allocator.c
+++ b/src/lib/kinetic_allocator.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -27,7 +27,7 @@
 KineticSession* KineticAllocator_NewSession(struct bus * b, KineticSessionConfig* config)
 {
     (void)b; // TODO: combine session w/connection, which will use this variable
-    
+
     // Allocate a new session
     KineticSession* session = KineticCalloc(1, sizeof(KineticSession));
     if (session == NULL) {

--- a/src/lib/kinetic_allocator.h
+++ b/src/lib/kinetic_allocator.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_auth.c
+++ b/src/lib/kinetic_auth.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -88,7 +88,7 @@ KineticStatus KineticAuth_PopulatePin(KineticSessionConfig const * const config,
     msg->message.authtype = COM__SEAGATE__KINETIC__PROTO__MESSAGE__AUTH_TYPE__PINAUTH;
     msg->message.has_authtype = true;
     msg->command.header = &msg->header;
-    
+
     // Configure PIN support
     KINETIC_ASSERT(pin.len <= KINETIC_PIN_MAX_LEN);
     if (pin.len > 0) { KINETIC_ASSERT(pin.data != NULL); }

--- a/src/lib/kinetic_auth.h
+++ b/src/lib/kinetic_auth.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_builder.c
+++ b/src/lib/kinetic_builder.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "kinetic_builder.h"
 #include "kinetic_operation.h"
 #include "kinetic_controller.h"

--- a/src/lib/kinetic_builder.c
+++ b/src/lib/kinetic_builder.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -203,7 +203,7 @@ Com__Seagate__Kinetic__Proto__Command__P2POperation* build_p2pOp(uint32_t nestin
 
     for(size_t i = 0; i < proto_p2pOp->n_operation; i++) {
         KINETIC_ASSERT(!ByteBuffer_IsNull(p2pOp->operations[i].key)); // TODO return invalid operand?
-        
+
         Com__Seagate__Kinetic__Proto__Command__P2POperation__Operation * p2p_op_op = calloc(1, sizeof(Com__Seagate__Kinetic__Proto__Command__P2POperation__Operation));
         if (p2p_op_op == NULL) { goto error_cleanup; }
 
@@ -247,7 +247,7 @@ KineticStatus KineticBuilder_BuildP2POperation(KineticOperation* const op,
                                                  KineticP2P_Operation* const p2pOp)
 {
     KineticOperation_ValidateOperation(op);
-        
+
     op->request->command->header->messagetype = COM__SEAGATE__KINETIC__PROTO__COMMAND__MESSAGE_TYPE__PEER2PEERPUSH;
     op->request->command->header->has_messagetype = true;
     op->request->command->body = &op->request->message.body;
@@ -255,7 +255,7 @@ KineticStatus KineticBuilder_BuildP2POperation(KineticOperation* const op,
     op->opCallback = &KineticCallbacks_P2POperation;
 
     op->request->command->body->p2poperation = build_p2pOp(0, p2pOp);
-    
+
     if (op->request->command->body->p2poperation == NULL) {
         return KINETIC_STATUS_OPERATION_INVALID;
     }
@@ -277,7 +277,7 @@ KineticStatus KineticBuilder_BuildGetLog(KineticOperation* const op,
     Com__Seagate__Kinetic__Proto__Command__GetLog__Type type, ByteArray name, KineticLogInfo** info)
 {
     KineticOperation_ValidateOperation(op);
-        
+
     op->request->command->header->messagetype = COM__SEAGATE__KINETIC__PROTO__COMMAND__MESSAGE_TYPE__GETLOG;
     op->request->command->header->has_messagetype = true;
     op->request->command->body = &op->request->message.body;
@@ -327,7 +327,7 @@ KineticStatus KineticBuilder_BuildSetPin(KineticOperation* const op, ByteArray o
             .data = new_pin.data, .len = new_pin.len };
         op->request->message.security.has_newerasepin = true;
     }
-    
+
     op->opCallback = &KineticCallbacks_Basic;
     op->request->pinAuth = false;
     op->timeoutSeconds = KineticOperation_TimeoutSetPin;
@@ -348,7 +348,7 @@ KineticStatus KineticBuilder_BuildErase(KineticOperation* const op, bool secure_
         COM__SEAGATE__KINETIC__PROTO__COMMAND__PIN_OPERATION__PIN_OP_TYPE__SECURE_ERASE_PINOP :
         COM__SEAGATE__KINETIC__PROTO__COMMAND__PIN_OPERATION__PIN_OP_TYPE__ERASE_PINOP;
     op->request->command->body->pinop->has_pinoptype = true;
-    
+
     op->opCallback = &KineticCallbacks_Basic;
     op->request->pinAuth = true;
     op->timeoutSeconds = KineticOperation_TimeoutErase;
@@ -365,12 +365,12 @@ KineticStatus KineticBuilder_BuildLockUnlock(KineticOperation* const op, bool lo
     op->request->message.command.header->has_messagetype = true;
     op->request->command->body = &op->request->message.body;
     op->request->command->body->pinop = &op->request->message.pinOp;
-    
+
     op->request->command->body->pinop->pinoptype = lock ?
         COM__SEAGATE__KINETIC__PROTO__COMMAND__PIN_OPERATION__PIN_OP_TYPE__LOCK_PINOP :
         COM__SEAGATE__KINETIC__PROTO__COMMAND__PIN_OPERATION__PIN_OP_TYPE__UNLOCK_PINOP;
     op->request->command->body->pinop->has_pinoptype = true;
-    
+
     op->opCallback = &KineticCallbacks_Basic;
     op->request->pinAuth = true;
     op->timeoutSeconds = KineticOperation_TimeoutLockUnlock;
@@ -381,11 +381,11 @@ KineticStatus KineticBuilder_BuildLockUnlock(KineticOperation* const op, bool lo
 KineticStatus KineticBuilder_BuildSetClusterVersion(KineticOperation* op, int64_t new_cluster_version)
 {
     KineticOperation_ValidateOperation(op);
-    
+
     op->request->message.command.header->messagetype = COM__SEAGATE__KINETIC__PROTO__COMMAND__MESSAGE_TYPE__SETUP;
     op->request->message.command.header->has_messagetype = true;
     op->request->command->body = &op->request->message.body;
-    
+
     op->request->command->body->setup = &op->request->message.setup;
     op->request->command->body->setup->newclusterversion = new_cluster_version;
     op->request->command->body->setup->has_newclusterversion = true;
@@ -543,11 +543,11 @@ KineticStatus KineticBuilder_BuildUpdateFirmware(KineticOperation* const op, con
     fclose(fp);
 
     op->value.len = len;
-    
+
     op->request->message.command.header->messagetype = COM__SEAGATE__KINETIC__PROTO__COMMAND__MESSAGE_TYPE__SETUP;
     op->request->message.command.header->has_messagetype = true;
     op->request->command->body = &op->request->message.body;
-    
+
     op->request->command->body->setup = &op->request->message.setup;
     op->request->command->body->setup->firmwaredownload = true;
     op->request->command->body->setup->has_firmwaredownload = true;

--- a/src/lib/kinetic_builder.h
+++ b/src/lib/kinetic_builder.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_bus.c
+++ b/src/lib/kinetic_bus.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -40,7 +40,7 @@ static bus_sink_cb_res_t reset_transfer(socket_info *si) {
     bus_sink_cb_res_t res = { /* prime pump with header size */
         .next_read = sizeof(KineticPDUHeader),
     };
-    
+
     si->state = STATE_AWAITING_HEADER;
     si->accumulated = 0;
     si->unpack_status = UNPACK_ERROR_UNDEFINED;
@@ -124,7 +124,7 @@ STATIC bus_sink_cb_res_t sink_cb(uint8_t *read_buf,
             return res;
         }
         break;
-    } 
+    }
     case STATE_AWAITING_BODY:
     {
         memcpy(&si->buf[si->accumulated], read_buf, read_size);
@@ -137,7 +137,7 @@ STATIC bus_sink_cb_res_t sink_cb(uint8_t *read_buf,
             si->accumulated = 0;
             bus_sink_cb_res_t res = {
                 .next_read = sizeof(KineticPDUHeader),
-                // returning the whole si, because we need access to the pdu header as well 
+                // returning the whole si, because we need access to the pdu header as well
                 //  as the protobuf and value bytes
                 .full_msg_buffer = si,
             };
@@ -170,7 +170,7 @@ static void log_response_seq_id(int fd, int64_t seq_id) {
 STATIC bus_unpack_cb_res_t unpack_cb(void *msg, void *socket_udata) {
     KineticSession * session = (KineticSession*)socket_udata;
     KINETIC_ASSERT(session);
-    
+
     /* just got .full_msg_buffer from sink_cb -- pass it along as-is */
     socket_info *si = (socket_info *)msg;
 
@@ -192,7 +192,7 @@ STATIC bus_unpack_cb_res_t unpack_cb(void *msg, void *socket_udata) {
         return res;
     } else {
         response->header = si->header;
-        
+
         response->proto = KineticPDU_unpack_message(NULL, si->header.protobufLength, si->buf);
         if (response->proto->has_commandbytes &&
             response->proto->commandbytes.data != NULL &&

--- a/src/lib/kinetic_bus.h
+++ b/src/lib/kinetic_bus.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_callbacks.c
+++ b/src/lib/kinetic_callbacks.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "kinetic_operation.h"
 #include "kinetic_controller.h"
 #include "kinetic_session.h"

--- a/src/lib/kinetic_callbacks.c
+++ b/src/lib/kinetic_callbacks.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -247,6 +247,6 @@ KineticStatus KineticCallbacks_UpdateFirmware(KineticOperation* const operation,
         free(operation->value.data);
         memset(&operation->value, 0, sizeof(ByteArray));
     }
-    
+
     return status;
 }

--- a/src/lib/kinetic_callbacks.h
+++ b/src/lib/kinetic_callbacks.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_client.c
+++ b/src/lib/kinetic_client.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -45,9 +45,9 @@ KineticClient * KineticClient_Init(KineticClientConfig *config)
 {
     KineticLogger_Init(config->logFile, config->logLevel);
     KineticClient * client = KineticCalloc(1, sizeof(*client));
-    if (client == NULL) { 
+    if (client == NULL) {
         KineticLogger_Close();
-        return NULL; 
+        return NULL;
     }
 
     /* Use defaults if set to 0. */

--- a/src/lib/kinetic_controller.c
+++ b/src/lib/kinetic_controller.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -59,7 +59,7 @@ KineticStatus KineticController_ExecuteOperation(KineticOperation* operation, Ki
     KINETIC_ASSERT(operation->session != NULL);
     KineticStatus status = KINETIC_STATUS_INVALID;
     KineticSession *session = operation->session;
- 
+
     if (KineticSession_GetTerminationStatus(operation->session) != KINETIC_STATUS_SUCCESS) {
         return KINETIC_STATUS_SESSION_TERMINATED;
     }
@@ -143,7 +143,7 @@ KineticStatus bus_to_kinetic_status(bus_send_status_t const status)
             return KINETIC_STATUS_INVALID;
         }
     }
-    
+
     LOGF3("bus_to_kinetic_status: mapping status %d => %d",
         status, res);
     return res;
@@ -208,7 +208,7 @@ void KineticController_HandleUnexpectedResponse(void *msg,
         else {
             LOG0("WARNING: Unsolicited status received. Connection being terminated by remote!");
             logTag = statusTag;
-            logAtLevel = 0; 
+            logAtLevel = 0;
             protoLogAtLevel = 0;
             KineticStatus status = KineticResponse_GetStatus(response);
             KineticSession_SetTerminationStatus(session, status);

--- a/src/lib/kinetic_controller.h
+++ b/src/lib/kinetic_controller.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_countingsemaphore.c
+++ b/src/lib/kinetic_countingsemaphore.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "kinetic_countingsemaphore.h"
 #include "kinetic_countingsemaphore_types.h"
 #include "kinetic_logger.h"

--- a/src/lib/kinetic_countingsemaphore.c
+++ b/src/lib/kinetic_countingsemaphore.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -48,9 +48,9 @@ void KineticCountingSemaphore_Take(KineticCountingSemaphore * const sem) // WAIT
     uint32_t before = sem->count--;
     uint32_t after = sem->count;
     uint32_t waiting = sem->num_waiting;
-    
+
     pthread_mutex_unlock(&sem->mutex);
-    
+
     LOGF3("Concurrent ops throttle -- TAKE: %u => %u (waiting=%u)", before, after, waiting);
 }
 
@@ -58,7 +58,7 @@ void KineticCountingSemaphore_Give(KineticCountingSemaphore * const sem) // SIGN
 {
     KINETIC_ASSERT(sem != NULL);
     pthread_mutex_lock(&sem->mutex);
-    
+
     if (sem->count == 0 && sem->num_waiting > 0) {
         pthread_cond_signal(&sem->available);
     }
@@ -66,9 +66,9 @@ void KineticCountingSemaphore_Give(KineticCountingSemaphore * const sem) // SIGN
     uint32_t before = sem->count++;
     uint32_t after = sem->count;
     uint32_t waiting = sem->num_waiting;
-    
+
     pthread_mutex_unlock(&sem->mutex);
-    
+
     LOGF3("Concurrent ops throttle -- GIVE: %u => %u (waiting=%u)", before, after, waiting);
     KINETIC_ASSERT(sem->max >= after);
 }

--- a/src/lib/kinetic_countingsemaphore.h
+++ b/src/lib/kinetic_countingsemaphore.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef _KINETIC_COUNTINGSEMAPHORE_H
 #define _KINETIC_COUNTINGSEMAPHORE_H
 

--- a/src/lib/kinetic_countingsemaphore.h
+++ b/src/lib/kinetic_countingsemaphore.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_countingsemaphore_types.h
+++ b/src/lib/kinetic_countingsemaphore_types.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef _KINETIC_COUNTINGSEMAPHORE_TYPES_H
 #define _KINETIC_COUNTINGSEMAPHORE_TYPES_H
 

--- a/src/lib/kinetic_countingsemaphore_types.h
+++ b/src/lib/kinetic_countingsemaphore_types.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_device_info.c
+++ b/src/lib/kinetic_device_info.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -113,7 +113,7 @@ static KineticLogInfo_Configuration * KineticLogInfo_GetConfiguration(
 
     KineticLogInfo_Configuration *cfg = calloc(1, sizeof(*cfg));
     if (cfg) {
-        
+
 	if (gcfg->has_serialnumber) {
               cfg->serialNumber = copy_to_byte_array((uint8_t *)gcfg->serialnumber.data,
                     gcfg->serialnumber.len);
@@ -133,7 +133,7 @@ static KineticLogInfo_Configuration * KineticLogInfo_GetConfiguration(
         }
 
         cfg->vendor = copy_str(gcfg->vendor);
-        
+
         if (cfg->vendor == NULL) { goto cleanup; }
         cfg->model = copy_str(gcfg->model);
         if (cfg->model == NULL) { goto cleanup; }
@@ -184,7 +184,7 @@ static KineticLogInfo_Configuration * KineticLogInfo_GetConfiguration(
     }
     return cfg;
 cleanup:
-    
+
     free_byte_array(cfg->serialNumber);
     free_byte_array(cfg->worldWideName);
     if (cfg->vendor) { free(cfg->vendor); }
@@ -287,7 +287,7 @@ KineticLogInfo* KineticLogInfo_Create(const Com__Seagate__Kinetic__Proto__Comman
     KineticLogInfo_Configuration* configuration = NULL;
     KineticLogInfo_Statistics* statistics = NULL;
     KineticLogInfo_Limits* limits = NULL;
-    KineticLogInfo_Device* device = NULL;    
+    KineticLogInfo_Device* device = NULL;
 
     utilizations = KineticLogInfo_GetUtilizations(getLog, &info->numUtilizations);
     if (utilizations == NULL) { goto cleanup; }
@@ -347,16 +347,16 @@ void KineticLogInfo_Free(KineticLogInfo* kdi) {
             }
             free(kdi->utilizations);
         }
-        
+
         if (kdi->temperatures) {
             for (size_t i = 0; i < kdi->numTemperatures; i++) {
                 free(kdi->temperatures[i].name);
             }
             free(kdi->temperatures);
         }
-        
+
         if (kdi->capacity) { free(kdi->capacity); }
-        
+
         if (kdi->configuration) {
             KineticLogInfo_Configuration *cfg = kdi->configuration;
 
@@ -384,10 +384,10 @@ void KineticLogInfo_Free(KineticLogInfo* kdi) {
             }
             free(cfg);
         }
-        
+
         if (kdi->statistics) { free(kdi->statistics); }
         if (kdi->limits) { free(kdi->limits); }
-        
+
         if (kdi->device) {
             if (kdi->device->name.data) { free(kdi->device->name.data); }
             free(kdi->device);

--- a/src/lib/kinetic_device_info.h
+++ b/src/lib/kinetic_device_info.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_engine.c
+++ b/src/lib/kinetic_engine.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_engine.h
+++ b/src/lib/kinetic_engine.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -21,7 +21,7 @@
 #include "kinetic_types_internal.h"
 
 typedef struct _KineticEngine {
-    
+
 } KineticEngine;
 
 KineticStatus KineticEngine_Startup(KineticEngine * const engine);

--- a/src/lib/kinetic_entry.c
+++ b/src/lib/kinetic_entry.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_entry.h
+++ b/src/lib/kinetic_entry.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_hmac.c
+++ b/src/lib/kinetic_hmac.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -127,7 +127,7 @@ static void KineticHMAC_Compute(KineticHMAC* hmac,
     for (size_t i = 0; i < sizeof(uint32_t); i++) {
         fprintf(stderr, "%02x", ((uint8_t *)&lenNBO)[i]);
     }
-    
+
     fprintf(stderr, "' on data: \n");
     for (size_t i = 0; i < msg->commandbytes.len; i++) {
         fprintf(stderr, "%02x", msg->commandbytes.data[i]);

--- a/src/lib/kinetic_hmac.h
+++ b/src/lib/kinetic_hmac.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_logger.c
+++ b/src/lib/kinetic_logger.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -62,7 +62,7 @@ void KineticLogger_Init(const char* log_file, int log_level)
     }
     else {
         KineticLogLevel = log_level;
-        
+
         if (strncmp(log_file, "stdout", 4) == 0 || strncmp(log_file, "STDOUT", 4) == 0) {
             if (log_level > 0) {
                 printf("Logging kinetic-c output to console (stdout) w/ log_level=%d\n", KineticLogLevel);
@@ -113,7 +113,7 @@ void KineticLogger_LogPrintf(int log_level, const char* format, ...)
         fprintf(KineticLoggerHandle, "%08lld.%06lld  ",
             (long long)tv.tv_sec, (long long)tv.tv_usec);
     }
-    
+
     va_list arg_ptr;
     va_start(arg_ptr, format);
     int len = vsnprintf(buffer, BUFFER_MAX_STRLEN, format, arg_ptr);
@@ -123,7 +123,7 @@ void KineticLogger_LogPrintf(int log_level, const char* format, ...)
         Buffer[BUFFER_MAX_STRLEN] = '\0';
     }
     strcat(Buffer, "\n");
-    
+
     finish_buffer();
 }
 
@@ -166,7 +166,7 @@ void KineticLogger_LogHeader(int log_level, const KineticPDUHeader* header)
 static char indent[64] = LOG_INDENT;
 static const size_t max_indent = sizeof(indent)-3;
 static int indent_overflow = 0;
-    
+
 
 static void log_proto_level_start(const char* name)
 {
@@ -381,10 +381,10 @@ static void log_protobuf_message(int log_level, ProtobufCMessage const * msg, ch
                 protobuf_c_boolean const * quantifier = (protobuf_c_boolean const *)(void*)&pMsg[fieldDesc->quantifier_offset];
                 if ((*quantifier) &&  // only print out if it's there
                     // and a special case: if this is a message, don't show it if the message is NULL
-                    (PROTOBUF_C_TYPE_MESSAGE != fieldDesc->type || ((ProtobufCMessage**)(void*)&pMsg[fieldDesc->offset])[0] != NULL)) 
+                    (PROTOBUF_C_TYPE_MESSAGE != fieldDesc->type || ((ProtobufCMessage**)(void*)&pMsg[fieldDesc->offset])[0] != NULL))
                 {
                     // special case for nested command packed into commandBytes field
-                    if ((protobuf_c_message_descriptor_get_field_by_name(desc, "commandBytes") == fieldDesc ) && 
+                    if ((protobuf_c_message_descriptor_get_field_by_name(desc, "commandBytes") == fieldDesc ) &&
                         (PROTOBUF_C_TYPE_BYTES == fieldDesc->type))
                     {
                         ProtobufCBinaryData* value = (ProtobufCBinaryData*)(void*)&pMsg[fieldDesc->offset];

--- a/src/lib/kinetic_logger.h
+++ b/src/lib/kinetic_logger.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_memory.c
+++ b/src/lib/kinetic_memory.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "kinetic_memory.h"
 
 #include <stdlib.h>

--- a/src/lib/kinetic_memory.c
+++ b/src/lib/kinetic_memory.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_memory.h
+++ b/src/lib/kinetic_memory.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_message.c
+++ b/src/lib/kinetic_message.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -92,7 +92,7 @@ void KineticMessage_ConfigureKeyRange(KineticMessage* const message,
     message->command.body->range = &message->keyRange;
 
     // Populate startKey, if supplied
-    message->command.body->range->has_startkey = 
+    message->command.body->range->has_startkey =
         (range->startKey.array.data != NULL);
     if (message->command.body->range->has_startkey) {
         message->command.body->range->startkey = (ProtobufCBinaryData) {
@@ -102,7 +102,7 @@ void KineticMessage_ConfigureKeyRange(KineticMessage* const message,
     }
 
     // Populate endKey, if supplied
-    message->command.body->range->has_endkey = 
+    message->command.body->range->has_endkey =
         (range->endKey.array.data != NULL);
     if (message->command.body->range->has_endkey) {
         message->command.body->range->endkey = (ProtobufCBinaryData) {

--- a/src/lib/kinetic_message.h
+++ b/src/lib/kinetic_message.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_nbo.c
+++ b/src/lib/kinetic_nbo.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_nbo.h
+++ b/src/lib/kinetic_nbo.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_operation.c
+++ b/src/lib/kinetic_operation.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "kinetic_operation.h"
 #include "kinetic_controller.h"
 #include "kinetic_session.h"

--- a/src/lib/kinetic_operation.c
+++ b/src/lib/kinetic_operation.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -53,7 +53,7 @@ KineticStatus KineticOperation_SendRequest(KineticOperation* const op)
 {
     KineticSession *session = op->session;
     KineticOperation_ValidateOperation(op);
-    
+
     if (!KineticRequest_LockSend(session)) {
         return KINETIC_STATUS_CONNECTION_ERROR;
     }
@@ -106,7 +106,7 @@ static KineticStatus send_request_in_lock(KineticOperation* const op)
         op->request, op->pin);
     if (status != KINETIC_STATUS_SUCCESS) {
         if (commandData) { free(commandData); }
-        return status;        
+        return status;
     }
 
     #ifndef TEST

--- a/src/lib/kinetic_operation.h
+++ b/src/lib/kinetic_operation.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_pdu_unpack.c
+++ b/src/lib/kinetic_pdu_unpack.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_pdu_unpack.h
+++ b/src/lib/kinetic_pdu_unpack.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_request.c
+++ b/src/lib/kinetic_request.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "kinetic_request.h"
 #include <pthread.h>
 

--- a/src/lib/kinetic_request.c
+++ b/src/lib/kinetic_request.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -113,7 +113,7 @@ KineticStatus KineticRequest_PackMessage(KineticOperation *operation,
     KineticLogger_LogHeader(3, &header);
     KineticLogger_LogProtobuf(3, proto);
     #endif
-    
+
     // Pack value payload, if supplied
     if (header.valueLength > 0) {
         memcpy(&msg[offset], operation->value.data, operation->value.len);

--- a/src/lib/kinetic_request.h
+++ b/src/lib/kinetic_request.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef KINETIC_REQUEST_H
 #define KINETIC_REQUEST_H
 

--- a/src/lib/kinetic_request.h
+++ b/src/lib/kinetic_request.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_resourcewaiter.c
+++ b/src/lib/kinetic_resourcewaiter.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "kinetic_resourcewaiter.h"
 #include "kinetic_resourcewaiter_types.h"
 #include "kinetic_logger.h"

--- a/src/lib/kinetic_resourcewaiter.c
+++ b/src/lib/kinetic_resourcewaiter.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -38,7 +38,7 @@ void KineticResourceWaiter_SetAvailable(KineticResourceWaiter * const waiter)
     if (waiter->num_waiting > 0) {
         pthread_cond_signal(&waiter->ready_cond);
     }
-    
+
     pthread_mutex_unlock(&waiter->mutex);
 }
 

--- a/src/lib/kinetic_resourcewaiter.h
+++ b/src/lib/kinetic_resourcewaiter.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_resourcewaiter.h
+++ b/src/lib/kinetic_resourcewaiter.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef _KINETIC_RESOURCEWAITER_H
 #define _KINETIC_RESOURCEWAITER_H
 

--- a/src/lib/kinetic_resourcewaiter_types.h
+++ b/src/lib/kinetic_resourcewaiter_types.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef _KINETIC_RESOURCEWAITER_TYPES_H
 #define _KINETIC_RESOURCEWAITER_TYPES_H
 

--- a/src/lib/kinetic_resourcewaiter_types.h
+++ b/src/lib/kinetic_resourcewaiter_types.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_response.c
+++ b/src/lib/kinetic_response.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_response.h
+++ b/src/lib/kinetic_response.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_semaphore.c
+++ b/src/lib/kinetic_semaphore.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "kinetic_semaphore.h"
 #include <pthread.h>
 #include <stdlib.h>

--- a/src/lib/kinetic_semaphore.c
+++ b/src/lib/kinetic_semaphore.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -42,7 +42,7 @@ void KineticSemaphore_Signal(KineticSemaphore * sem)
     pthread_mutex_lock(&sem->mutex);
     sem->signaled = true;
     pthread_cond_signal(&sem->complete);
-    pthread_mutex_unlock(&sem->mutex); 
+    pthread_mutex_unlock(&sem->mutex);
 }
 
 bool KineticSemaphore_CheckSignaled(KineticSemaphore * sem)
@@ -69,7 +69,7 @@ void KineticSemaphore_WaitForSignalAndDestroy(KineticSemaphore * sem)
     if (!sem->signaled) {
         pthread_cond_wait(&sem->complete, &sem->mutex);
     }
-    pthread_mutex_unlock(&sem->mutex); 
+    pthread_mutex_unlock(&sem->mutex);
 
     pthread_mutex_destroy(&sem->mutex);
     pthread_cond_destroy(&sem->complete);

--- a/src/lib/kinetic_session.c
+++ b/src/lib/kinetic_session.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -45,7 +45,7 @@ KineticStatus KineticSession_Create(KineticSession * const session, KineticClien
 
     session->connected = false;
     session->socket = KINETIC_SOCKET_INVALID;
-    
+
     // initialize session send mutex
     if (pthread_mutex_init(&session->sendMutex, NULL) != 0) {
         LOG0("Failed initializing session send mutex!");
@@ -133,7 +133,7 @@ KineticStatus KineticSession_Disconnect(KineticSession * const session)
     if (!session->connected || session->socket < 0) {
         return KINETIC_STATUS_CONNECTION_ERROR;
     }
-    
+
     // Close the connection
     KineticSocket_Close(session->socket);
     Bus_ReleaseSocket(session->messageBus, session->socket, NULL);

--- a/src/lib/kinetic_session.h
+++ b/src/lib/kinetic_session.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_socket.c
+++ b/src/lib/kinetic_socket.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_socket.h
+++ b/src/lib/kinetic_socket.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_types.c
+++ b/src/lib/kinetic_types.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -70,7 +70,7 @@ const char* Kinetic_GetStatusDescription(KineticStatus status)
 }
 
 const char* KineticMessageTypeNames[33] =
-{  
+{
     "<UNKNOWN>",
     "GET_RESPONSE",
     "GET",
@@ -128,7 +128,7 @@ const char* KineticMessageType_GetName(KineticMessageType type)
 	return "DELETE";
 	break;
     case KINETIC_MESSAGE_TYPE_GETNEXT_RESPONSE:
-	return "GETNEXT_RESPONSE";    
+	return "GETNEXT_RESPONSE";
 	break;
     case KINETIC_MESSAGE_TYPE_GETNEXT:
 	return  "GETNEXT";
@@ -143,7 +143,7 @@ const char* KineticMessageType_GetName(KineticMessageType type)
 	return "GETKEYRANGE_RESPONSE";
 	break;
     case KINETIC_MESSAGE_TYPE_GETKEYRANGE:
-	return "GETKEYRANGE";    
+	return "GETKEYRANGE";
 	break;
     case KINETIC_MESSAGE_TYPE_GETVERSION_RESPONSE:
 	return "GETVERSION_RESPONSE";

--- a/src/lib/kinetic_types_internal.c
+++ b/src/lib/kinetic_types_internal.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/kinetic_types_internal.h
+++ b/src/lib/kinetic_types_internal.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/threadpool/Makefile
+++ b/src/lib/threadpool/Makefile
@@ -11,14 +11,14 @@ LDFLAGS +=	-lpthread
 TEST_CFLAGS = 	${CFLAGS}
 TEST_LDFLAGS += ${LDFLAGS} -L. -lthreadpool
 
-all: test_${PROJECT} 
+all: test_${PROJECT}
 all: test_${PROJECT}_stress
 all: test_${PROJECT}_sequencing
 all: lib${PROJECT}.a
 
 OBJS=		threadpool.o
 
-TEST_OBJS=	
+TEST_OBJS=
 
 # Basic targets
 

--- a/src/lib/threadpool/test_threadpool.c
+++ b/src/lib/threadpool/test_threadpool.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/src/lib/threadpool/test_threadpool.c
+++ b/src/lib/threadpool/test_threadpool.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -56,7 +56,7 @@ static void task_cb(void *udata) {
     size_t res = fibs(arg);
 
     printf("%zd -- fibs(%zd) => %zd", tc, arg, res);
-    
+
     struct threadpool_info stats;
     Threadpool_Stats(t, &stats);
     dump_stats("", &stats);

--- a/src/lib/threadpool/test_threadpool_sequencing.c
+++ b/src/lib/threadpool/test_threadpool_sequencing.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/src/lib/threadpool/test_threadpool_sequencing.c
+++ b/src/lib/threadpool/test_threadpool_sequencing.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -93,7 +93,7 @@ int main(int argc, char **argv) {
         printf("too many threads\n");
         exit(1);
     }
-    
+
     struct threadpool_config cfg = {
         .task_ringbuf_size2 = sz2,
         .max_threads = max_threads,
@@ -112,7 +112,7 @@ int main(int argc, char **argv) {
     struct threadpool_task tasks[MAX_TASKS];
     env envs[MAX_TASKS];
     memset(&tasks, 0, sizeof(tasks));
-    
+
     for (int i = 0; i < max_threads; i++) {
         envs[i] = (env){ .t = t, .task = &tasks[i], .count = 0, };
         tasks[i] = (struct threadpool_task){ .task = task_cb, .udata = &envs[i], };
@@ -121,7 +121,7 @@ int main(int argc, char **argv) {
             if (Threadpool_Schedule(t, &tasks[i], &counterpressure)) {
                 break;
             }
-        }        
+        }
     }
 
     printf("waiting...\n");

--- a/src/lib/threadpool/test_threadpool_stress.c
+++ b/src/lib/threadpool/test_threadpool_stress.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/src/lib/threadpool/test_threadpool_stress.c
+++ b/src/lib/threadpool/test_threadpool_stress.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/threadpool/threadpool.c
+++ b/src/lib/threadpool/threadpool.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include <stdio.h>
 #include <pthread.h>
 #include <unistd.h>

--- a/src/lib/threadpool/threadpool.c
+++ b/src/lib/threadpool/threadpool.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -42,7 +42,7 @@ static void set_defaults(struct threadpool_config *cfg) {
     if (cfg->task_ringbuf_size2 == 0) {
         cfg->task_ringbuf_size2 = DEFAULT_TASK_RINGBUF_SIZE2;
     }
-    
+
     if (cfg->max_threads == 0) { cfg->max_threads = DEFAULT_MAX_THREADS; }
 }
 
@@ -229,7 +229,7 @@ static void notify_new_task(struct threadpool *t) {
 
 static bool notify_shutdown(struct threadpool *t) {
     int done = 0;
-    
+
     for (int i = 0; i < t->live_threads; i++) {
         struct thread_info *ti = &t->threads[i];
         if (ti->status == STATUS_JOINED) {
@@ -248,7 +248,7 @@ static bool notify_shutdown(struct threadpool *t) {
             close(ti->parent_fd);
         }
     }
-    
+
     return (done == t->live_threads);
 }
 
@@ -283,7 +283,7 @@ static bool spawn(struct threadpool *t) {
         return false;
     } else {
         assert(false);
-    }                    
+    }
 }
 
 static void *thread_task(void *arg) {

--- a/src/lib/threadpool/threadpool.h
+++ b/src/lib/threadpool/threadpool.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef THREADPOOL_H
 #define THREADPOOL_H
 

--- a/src/lib/threadpool/threadpool.h
+++ b/src/lib/threadpool/threadpool.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/src/lib/threadpool/threadpool_internals.h
+++ b/src/lib/threadpool/threadpool_internals.h
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #ifndef THREADPOOL_INTERNALS_H
 #define THREADPOOL_INTERNALS_H
 

--- a/src/lib/threadpool/threadpool_internals.h
+++ b/src/lib/threadpool/threadpool_internals.h
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -50,7 +50,7 @@ struct marked_task {
     void *udata;
     /* This mark is used to indicate which tasks can have the commit_head
      * and release_head counters advanced past them.
-     * 
+     *
      * mark == (task_commit_head that points at tast): commit
      * mark == ~(task_release_head that points at tast): release
      *

--- a/src/utility/discovery.c
+++ b/src/utility/discovery.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -38,8 +38,8 @@ int main(int argc, char** argv)
     (void)argv;
     return discover_service();
 }
- 
-   
+
+
 //------------------------------------------------------------------------------
 // Service discovery
 
@@ -91,6 +91,6 @@ static int discover_service(void) {
             /* TODO: sink into json, print decoded data. */
         }
     }
-    
+
     return 0;
 }

--- a/src/utility/main.c
+++ b/src/utility/main.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -118,7 +118,7 @@ void PrintUsage(const char* exec)
 {
     printf("Usage: %s --<cmd> [options...]\n", exec);
     printf("%s --help\n", exec);
-    
+
     // Standard API operations
     printf("%s --noop"
       " [--host <ip|hostname>] [--port <port>] [--clusterversion <clusterversion>]\n", exec);
@@ -132,7 +132,7 @@ void PrintUsage(const char* exec)
       " [--host <ip|hostname>] [--port <port>] [--clusterversion <clusterversion>]\n", exec);
     printf("%s --delete --key <key>"
       " [--host <ip|hostname>] [--port <port>] [--clusterversion <clusterversion>]\n", exec);
-    
+
     // Admin API operations
     printf("%s --getlog --logtype <utilizations|temperatures|capacities|configuration|statistics|messages|limits>"
       " [--host <ip|hostname>] [--tlsport <tlsport>] [--clusterversion <clusterversion>]\n", exec);
@@ -241,13 +241,13 @@ static void PrintLogInfo(KineticLogInfo_Type type, KineticLogInfo* info)
                     info->utilizations[i].value * 100.0f);
             }
             break;
-        
+
         case KINETIC_DEVICE_INFO_TYPE_CAPACITIES:
             printf("Device Capacities:\n");
             printf("  nominalCapacity: %.3f MB\n", info->capacity->nominalCapacityInBytes / (1024.0f * 1024.0f));
             printf("  portionFull:     %.2f %%\n", info->capacity->portionFull * 100.0f);
             break;
-        
+
         case KINETIC_DEVICE_INFO_TYPE_TEMPERATURES:
             printf("Device Temperatures:\n");
             for (i = 0; i < info->numTemperatures; i++) {
@@ -257,7 +257,7 @@ static void PrintLogInfo(KineticLogInfo_Type type, KineticLogInfo* info)
                     info->temperatures[i].maximum, info->temperatures[i].target);
             }
             break;
-        
+
         case KINETIC_DEVICE_INFO_TYPE_CONFIGURATION:
             printf("Device Configuration:\n");
             printf("  vendor: %s\n", info->configuration->vendor);
@@ -287,7 +287,7 @@ static void PrintLogInfo(KineticLogInfo_Type type, KineticLogInfo* info)
             printf("  port: %d\n", info->configuration->port);
             printf("  tlsPort: %d\n", info->configuration->tlsPort);
             break;
-        
+
         case KINETIC_DEVICE_INFO_TYPE_STATISTICS:
             printf("Device Statistics:\n");
             for (i = 0; i < info->numStatistics; i++) {
@@ -297,7 +297,7 @@ static void PrintLogInfo(KineticLogInfo_Type type, KineticLogInfo* info)
                     (long long)info->statistics[i].bytes);
             }
             break;
-        
+
         case KINETIC_DEVICE_INFO_TYPE_MESSAGES:
             printf("Device Log Messages:\n"); {
                 char* msgs = calloc(1, info->messages.len + 1);
@@ -306,7 +306,7 @@ static void PrintLogInfo(KineticLogInfo_Type type, KineticLogInfo* info)
                 free(msgs);
             }
             break;
-        
+
         case KINETIC_DEVICE_INFO_TYPE_LIMITS:
             printf("Device Limits:\n");
             printf("  maxKeySize: %u\n",                  info->limits->maxKeySize);
@@ -321,7 +321,7 @@ static void PrintLogInfo(KineticLogInfo_Type type, KineticLogInfo* info)
             printf("  maxIdentityCount: %u\n",            info->limits->maxIdentityCount);
             printf("  maxPinSize: %u\n",                  info->limits->maxPinSize);
             break;
-        
+
         default:
             fprintf(stderr, "Unknown log type! (%d)\n", type);
             break;

--- a/test/integration/test_kinetic.pb-c.c
+++ b/test/integration/test_kinetic.pb-c.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/integration/test_kinetic_logger.c
+++ b/test/integration/test_kinetic_logger.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/integration/test_kinetic_socket.c
+++ b/test/integration/test_kinetic_socket.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/support/system_test_fixture.c
+++ b/test/support/system_test_fixture.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/support/system_test_kv_generate.c
+++ b/test/support/system_test_kv_generate.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_kv_generate.h"
 #include <stdlib.h>
 #include <string.h>

--- a/test/support/system_test_kv_generate.c
+++ b/test/support/system_test_kv_generate.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/system/test_system_async_io.c
+++ b/test/system/test_system_async_io.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_client.h"
 #include "kinetic_semaphore.h"

--- a/test/system/test_system_async_io.c
+++ b/test/system/test_system_async_io.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -127,7 +127,7 @@ void test_kinetic_client_should_store_a_binary_object_split_across_entries_via_o
         bytes_written / 1024.0f,
         elapsed_ms / 1000.0f,
         bandwidth);
-    
+
     printf("Transfer completed successfully!\n");
 
     ByteBuffer_Free(test_data);

--- a/test/system/test_system_async_throughput.c
+++ b/test/system/test_system_async_throughput.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_client.h"
 #include "kinetic_semaphore.h"

--- a/test/system/test_system_async_throughput.c
+++ b/test/system/test_system_async_throughput.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/system/test_system_bus.c
+++ b/test/system/test_system_bus.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "byte_array.h"
 #include "unity.h"
 #include "unity_helper.h"

--- a/test/system/test_system_bus.c
+++ b/test/system/test_system_bus.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -51,7 +51,7 @@ static bus_sink_cb_res_t reset_transfer(socket_info *si) {
     bus_sink_cb_res_t res = { /* prime pump with header size */
         .next_read = sizeof(KineticPDUHeader),
     };
-    
+
     si->state = STATE_AWAITING_HEADER;
     si->accumulated = 0;
     si->unpack_status = UNPACK_ERROR_UNDEFINED;
@@ -66,7 +66,7 @@ static bool unpack_header(uint8_t const * const read_buf, size_t const read_size
         return false;
         // TODO this will fail if we don't get all of the header bytes in one read
         // we should fix this
-    } 
+    }
     KineticPDUHeader const * const buf_header = (KineticPDUHeader const * const)read_buf;
     uint32_t protobufLength = KineticNBO_ToHostU32(buf_header->protobufLength);
     uint32_t valueLength = KineticNBO_ToHostU32(buf_header->valueLength);
@@ -119,7 +119,7 @@ static bus_sink_cb_res_t sink_cb(uint8_t *read_buf, size_t read_size, void *sock
             return res;
         }
         break;
-    } 
+    }
     case STATE_AWAITING_BODY:
     {
         memcpy(&si->buf[si->accumulated], read_buf, read_size);
@@ -131,7 +131,7 @@ static bus_sink_cb_res_t sink_cb(uint8_t *read_buf, size_t read_size, void *sock
             si->state = STATE_AWAITING_HEADER;
             bus_sink_cb_res_t res = {
                 .next_read = sizeof(KineticPDUHeader),
-                // returning the whole si, because we need access to the pdu header as well 
+                // returning the whole si, because we need access to the pdu header as well
                 //  as the protobuf and value bytes
                 .full_msg_buffer = si,
             };

--- a/test/system/test_system_delete.c
+++ b/test/system/test_system_delete.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/system/test_system_delete.c
+++ b/test/system/test_system_delete.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_client.h"
 

--- a/test/system/test_system_erase.c
+++ b/test/system/test_system_erase.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_admin_client.h"
 

--- a/test/system/test_system_erase.c
+++ b/test/system/test_system_erase.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -92,7 +92,7 @@ void setUp(void)
 void tearDown(void)
 {
     KineticStatus status = KINETIC_STATUS_INVALID;
-    
+
     if (failing) { return; }
 
     // Validate the object no longer exists

--- a/test/system/test_system_fatal_errors.c
+++ b/test/system/test_system_fatal_errors.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_client.h"
 #include "kinetic_admin_client.h"

--- a/test/system/test_system_fatal_errors.c
+++ b/test/system/test_system_fatal_errors.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/system/test_system_flush.c
+++ b/test/system/test_system_flush.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/system/test_system_flush.c
+++ b/test/system/test_system_flush.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_client.h"
 

--- a/test/system/test_system_get.c
+++ b/test/system/test_system_get.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_client.h"
 #include "system_test_kv_generate.h"

--- a/test/system/test_system_get.c
+++ b/test/system/test_system_get.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/system/test_system_get_log.c
+++ b/test/system/test_system_get_log.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_admin_client.h"
 #include "kinetic_device_info.h"

--- a/test/system/test_system_get_log.c
+++ b/test/system/test_system_get_log.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -79,7 +79,7 @@ void test_GetLog_should_retrieve_temeratures_from_device(void)
 void test_GetLog_should_retrieve_configuration_from_device(void)
 {
     char buf[1024];
-    
+
     Status = KineticAdminClient_GetLog(Fixture.session, KINETIC_DEVICE_INFO_TYPE_CONFIGURATION, &Info, NULL);
 
     TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, Status);
@@ -156,7 +156,7 @@ void test_GetLog_should_retrieve_limits_from_device(void)
     TEST_ASSERT_NOT_NULL(Info->limits);
 
     LOG0("Device Limits:");
-    LOGF0("  maxKeySize: %u",                  Info->limits->maxKeySize);    
+    LOGF0("  maxKeySize: %u",                  Info->limits->maxKeySize);
     LOGF0("  maxValueSize: %u",                Info->limits->maxValueSize);
     LOGF0("  maxVersionSize: %u",              Info->limits->maxVersionSize);
     LOGF0("  maxTagSize: %u",                  Info->limits->maxTagSize);

--- a/test/system/test_system_getkeyrange.c
+++ b/test/system/test_system_getkeyrange.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_client.h"
 

--- a/test/system/test_system_getkeyrange.c
+++ b/test/system/test_system_getkeyrange.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -145,7 +145,7 @@ void test_GetKeyRange_should_retrieve_a_range_of_keys_from_device_with_start_and
     ByteBufferArray keys = {.buffers = &keyBuff[0], .count = numKeys};
 
     KineticStatus status = KineticClient_GetKeyRange(Fixture.session, &range, &keys, NULL);
-    
+
     TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
     TEST_ASSERT_EQUAL(1, keys.used);
     TEST_ASSERT_EQUAL_STRING("mykey_01", keyBuff[0].array.data);

--- a/test/system/test_system_getnext_getprevious.c
+++ b/test/system/test_system_getnext_getprevious.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_client.h"
 

--- a/test/system/test_system_getnext_getprevious.c
+++ b/test/system/test_system_getnext_getprevious.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -108,7 +108,7 @@ static void compare_against_offset_key(GET_CMD cmd, bool metadataOnly)
         default:
             TEST_ASSERT(false);
         }
-        
+
         TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
 
         ByteBuffer expectedKeyBuffer = ByteBuffer_CreateAndAppendFormattedCString(key_exp_buf, sz, "key_%d", i);

--- a/test/system/test_system_idle.c
+++ b/test/system/test_system_idle.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include <unistd.h>
 #include <err.h>
 #include <sys/wait.h>

--- a/test/system/test_system_idle.c
+++ b/test/system/test_system_idle.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/system/test_system_lock_unlock.c
+++ b/test/system/test_system_lock_unlock.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_admin_client.h"
 

--- a/test/system/test_system_lock_unlock.c
+++ b/test/system/test_system_lock_unlock.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -136,7 +136,7 @@ void test_KineticAdmin_should_lock_and_unlock_a_device(void)
         status = KineticClient_Get(Fixture.session, &getEntry, NULL);
         TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_DEVICE_LOCKED, status);
     }
-    
+
     status = KineticAdminClient_UnlockDevice(Fixture.adminSession, NewPin);
     TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
     Locked = false;

--- a/test/system/test_system_media_scan_optimize.c
+++ b/test/system/test_system_media_scan_optimize.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/system/test_system_media_scan_optimize.c
+++ b/test/system/test_system_media_scan_optimize.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_admin_client.h"
 #include "system_test_kv_generate.h"

--- a/test/system/test_system_multi_process.c
+++ b/test/system/test_system_multi_process.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include <unistd.h>
 #include <err.h>
 #include <sys/wait.h>

--- a/test/system/test_system_multi_process.c
+++ b/test/system/test_system_multi_process.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -105,7 +105,7 @@ static void child_task(void) {
             .synchronization = sync,
             .force = true,
         };
-            
+
         put_statuses[i] = (OpStatus){
             .sem = KineticSemaphore_Create(),
             .status = KINETIC_STATUS_INVALID,

--- a/test/system/test_system_noop.c
+++ b/test/system/test_system_noop.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/system/test_system_noop.c
+++ b/test/system/test_system_noop.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_client.h"
 

--- a/test/system/test_system_overlapped_io.c
+++ b/test/system/test_system_overlapped_io.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_client.h"
 #include <stdlib.h>

--- a/test/system/test_system_overlapped_io.c
+++ b/test/system/test_system_overlapped_io.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -141,7 +141,7 @@ void test_kinetic_client_should_be_able_to_store_an_arbitrarily_large_binary_obj
 
         // Wait for each overlapped PUT operations to complete and cleanup
         printf("  *** Waiting for PUT threads to exit...\n");
-        aggregateBandwidthPerIteration[iteration] = 0.0f; 
+        aggregateBandwidthPerIteration[iteration] = 0.0f;
         for (int i = 0; i < NUM_COPIES; i++) {
             int join_status = pthread_join(thread_id[i], NULL);
             TEST_ASSERT_EQUAL_MESSAGE(0, join_status, "pthread join failed");
@@ -189,7 +189,7 @@ static void* kinetic_put(void* kinetic_arg)
     KineticEntry* entry = &(arg->entry);
     int32_t objIndex = 0;
     struct timeval startTime, stopTime;
-    
+
     gettimeofday(&startTime, NULL);
 
     while (ByteBuffer_BytesRemaining(arg->data) > 0) {

--- a/test/system/test_system_p2pop.c
+++ b/test/system/test_system_p2pop.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_client.h"
 #include "kinetic_admin_client.h"

--- a/test/system/test_system_p2pop.c
+++ b/test/system/test_system_p2pop.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -72,8 +72,8 @@ void setUp(void)
         .identity = 1,
         .hmacKey = ByteArray_CreateWithCString(HmacKeyString),
     };
-    strncpy(sessionConfig.host, GetSystemTestHost1(), sizeof(sessionConfig.host)-1); 
-    sessionConfig.port = GetSystemTestPort1(); 
+    strncpy(sessionConfig.host, GetSystemTestHost1(), sizeof(sessionConfig.host)-1);
+    sessionConfig.port = GetSystemTestPort1();
     KineticStatus status = KineticClient_CreateSession(&sessionConfig, client, &session);
     TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
     KineticSessionConfig adminSessionConfig = {
@@ -82,7 +82,7 @@ void setUp(void)
         .hmacKey = ByteArray_CreateWithCString(HmacKeyString),
         .useSsl = true,
     };
-    strncpy(adminSessionConfig.host, GetSystemTestHost1(), sizeof(adminSessionConfig.host)-1); 
+    strncpy(adminSessionConfig.host, GetSystemTestHost1(), sizeof(adminSessionConfig.host)-1);
     adminSessionConfig.port = GetSystemTestTlsPort1();
     status = KineticAdminClient_CreateSession(&adminSessionConfig, client, &adminSession);
     TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
@@ -93,8 +93,8 @@ void setUp(void)
         .identity = 1,
         .hmacKey = ByteArray_CreateWithCString(HmacKeyString),
     };
-    strncpy(peerConfig.host, GetSystemTestHost2(), sizeof(peerConfig.host)-1); 
-    peerConfig.port = GetSystemTestPort2(); 
+    strncpy(peerConfig.host, GetSystemTestHost2(), sizeof(peerConfig.host)-1);
+    peerConfig.port = GetSystemTestPort2();
     status = KineticClient_CreateSession(&peerConfig, client, &peerSession);
     TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
     KineticSessionConfig peerAdminConfig = {
@@ -103,8 +103,8 @@ void setUp(void)
         .identity = 1,
         .hmacKey = ByteArray_CreateWithCString(HmacKeyString),
     };
-    strncpy(peerAdminConfig.host, GetSystemTestHost2(), sizeof(peerAdminConfig.host)-1); 
-    peerAdminConfig.port = GetSystemTestTlsPort2(); 
+    strncpy(peerAdminConfig.host, GetSystemTestHost2(), sizeof(peerAdminConfig.host)-1);
+    peerAdminConfig.port = GetSystemTestTlsPort2();
     status = KineticAdminClient_CreateSession(&peerAdminConfig, client, &peerAdminSession);
     TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
 

--- a/test/system/test_system_p2pop_throughput.c
+++ b/test/system/test_system_p2pop_throughput.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_client.h"
 #include "kinetic_semaphore.h"

--- a/test/system/test_system_p2pop_throughput.c
+++ b/test/system/test_system_p2pop_throughput.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -43,7 +43,7 @@ void run_p2p_throughput_test(KineticClient * client, size_t num_ops, size_t valu
         .identity = 1,
         .hmacKey = ByteArray_CreateWithCString(HmacKeyString),
     };
-    strncpy(config1.host, GetSystemTestHost1(), sizeof(config1.host)-1); 
+    strncpy(config1.host, GetSystemTestHost1(), sizeof(config1.host)-1);
     config1.port = GetSystemTestPort1();
     KineticStatus status = KineticClient_CreateSession(&config1, client, &session1);
     TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
@@ -84,7 +84,7 @@ void run_p2p_throughput_test(KineticClient * client, size_t num_ops, size_t valu
         .identity = 1,
         .hmacKey = ByteArray_CreateWithCString(HmacKeyString),
     };
-    strncpy(config2.host, GetSystemTestHost2(), sizeof(config2.host)-1); 
+    strncpy(config2.host, GetSystemTestHost2(), sizeof(config2.host)-1);
     config2.port = GetSystemTestPort2();
 
     // P2P copy to another drive
@@ -190,5 +190,5 @@ void test_p2p_throughput(void)
     };
     KineticClient * client = KineticClient_Init(&config);
     run_p2p_throughput_test(client, 50, KINETIC_OBJ_SIZE);
-    KineticClient_Shutdown(client);   
+    KineticClient_Shutdown(client);
 }

--- a/test/system/test_system_put.c
+++ b/test/system/test_system_put.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/system/test_system_put.c
+++ b/test/system/test_system_put.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_client.h"
 

--- a/test/system/test_system_put_get_delete_mix.c
+++ b/test/system/test_system_put_get_delete_mix.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_client.h"
 #include "system_test_kv_generate.h"

--- a/test/system/test_system_put_get_delete_mix.c
+++ b/test/system/test_system_put_get_delete_mix.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/system/test_system_receive_thread.c
+++ b/test/system/test_system_receive_thread.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/system/test_system_receive_thread.c
+++ b/test/system/test_system_receive_thread.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_client.h"
 

--- a/test/system/test_system_security.c
+++ b/test/system/test_system_security.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_admin_client.h"
 

--- a/test/system/test_system_security.c
+++ b/test/system/test_system_security.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -101,7 +101,7 @@ void test_Secure_should_set_ACL_and_only_be_able_to_executed_permitted_operation
 
     SystemTestShutDown();
     SystemTestSetup(1, true);
-    
+
     /* Erase on identity 1 --> Permitted */
     status = KineticAdminClient_SetErasePin(Fixture.adminSession,
         OldPin, NewPin);

--- a/test/system/test_system_set_cluster_version.c
+++ b/test/system/test_system_set_cluster_version.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_admin_client.h"
 

--- a/test/system/test_system_set_cluster_version.c
+++ b/test/system/test_system_set_cluster_version.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -30,7 +30,7 @@ void tearDown(void)
 {
     if (ClusterVersionSet) {
         KineticStatus status = KineticAdminClient_SetClusterVersion(Fixture.adminSession, 0);
-        TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status); 
+        TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
     }
     SystemTestShutDown();
 }

--- a/test/system/test_system_set_pin.c
+++ b/test/system/test_system_set_pin.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_admin_client.h"
 

--- a/test/system/test_system_set_pin.c
+++ b/test/system/test_system_set_pin.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/system/test_system_stress_session_per_thread.c
+++ b/test/system/test_system_stress_session_per_thread.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_client.h"
 #include "kinetic_semaphore.h"

--- a/test/system/test_system_stress_session_per_thread.c
+++ b/test/system/test_system_stress_session_per_thread.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -299,7 +299,7 @@ static void* test_thread(void* test_params)
 
 void run_tests(KineticClient * client)
 {
-    TestParams params[] = { 
+    TestParams params[] = {
         { .client = client, .num_ops = 100, .obj_size = KINETIC_OBJ_SIZE, .thread_iters = 2 },
         { .client = client, .num_ops = 1000, .obj_size = 120, .thread_iters = 2 },
         // { .client = client, .num_ops = 500, .obj_size = 70000, .thread_iters = 2 },

--- a/test/system/test_system_stress_single_session_threaded.c
+++ b/test/system/test_system_stress_single_session_threaded.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "system_test_fixture.h"
 #include "kinetic_client.h"
 #include "kinetic_semaphore.h"

--- a/test/system/test_system_stress_single_session_threaded.c
+++ b/test/system/test_system_stress_single_session_threaded.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -358,7 +358,7 @@ void test_kinetic_client_throughput_test_kinetic_client_throughput_(void)
     }
 
     KineticClient_Shutdown(client);
-    
+
 }
 
 static void op_finished(KineticCompletionData* kinetic_data, void* clientData)

--- a/test/unit/acl/ex2.json
+++ b/test/unit/acl/ex2.json
@@ -1,7 +1,7 @@
 {
     "identity": 2,
     "key": "13010b8d8acdbe6abc005840aad1dc5dedb4345e681ed4e3c4645d891241d6b2",
-    "HMACAlgorithm": "HmacSHA1", 
+    "HMACAlgorithm": "HmacSHA1",
 
     "scope": [
         {

--- a/test/unit/acl/ex_multi.json
+++ b/test/unit/acl/ex_multi.json
@@ -17,7 +17,7 @@
 {
     "identity": 2,
     "key": "13010b8d8acdbe6abc005840aad1dc5dedb4345e681ed4e3c4645d891241d6b2",
-    "HMACAlgorithm": "HmacSHA1", 
+    "HMACAlgorithm": "HmacSHA1",
 
     "scope": [
         {

--- a/test/unit/test_bus.c
+++ b/test/unit/test_bus.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "unity.h"
 #include "bus.h"
 #include "bus_inward.h"

--- a/test/unit/test_bus.c
+++ b/test/unit/test_bus.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -290,7 +290,7 @@ void test_Bus_RegisterSocket_should_expose_Listener_AddSocket_failure(void)
     b.fd_set = &fake_yacht;
     Yacht_Set_ExpectAndReturn(b.fd_set, 35, test_ci, &old_value, true);
     Listener_AddSocket_ExpectAndReturn(&fake_listener, test_ci, &completion_pipe, false);
-    
+
     TEST_ASSERT_FALSE(Bus_RegisterSocket(&b, BUS_SOCKET_PLAIN, 35, NULL));
 }
 
@@ -617,7 +617,7 @@ void test_Bus_Shutdown_should_expose_pthread_join_failure(void)
         .listener_count = 2,
         .listeners = listeners,
         .joined = joined,
-        .threads = threads,        
+        .threads = threads,
     };
 
     struct yacht fake_yacht = { .size = 0, };

--- a/test/unit/test_bus_listener.c
+++ b/test/unit/test_bus_listener.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "unity.h"
 #include "listener.h"
 #include "listener_internal.h"

--- a/test/unit/test_bus_listener.c
+++ b/test/unit/test_bus_listener.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -188,7 +188,7 @@ void test_Listener_Free_should_unblock_pending_callers_and_close_file_handles(vo
     nl->incoming_msg_pipe = 149;
     nl->shutdown_notify_fd = LISTENER_SHUTDOWN_COMPLETE_FD;
     nl->read_buf = calloc(32, sizeof(uint32_t));
-    
+
     for (int i = 0; i < MAX_PENDING_MESSAGES; i++) {
         nl->rx_info[i].state = RIS_INACTIVE;
     }

--- a/test/unit/test_bus_listener_cmd.c
+++ b/test/unit/test_bus_listener_cmd.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "unity.h"
 #include "listener_cmd.h"
 #include "listener_cmd_internal.h"

--- a/test/unit/test_bus_listener_cmd.c
+++ b/test/unit/test_bus_listener_cmd.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -111,7 +111,7 @@ void test_ListenerCmd_CheckIncomingMessages_should_handle_redundant_ADD_SOCKET_c
     l->read_buf = malloc(256);
 
     connection_info *ci = calloc(1, sizeof(*ci));
-    *(int *)&ci->fd = 5;    
+    *(int *)&ci->fd = 5;
 
     listener_msg *msg = &l->msgs[0];
     msg->type = MSG_ADD_SOCKET;
@@ -129,7 +129,7 @@ void test_ListenerCmd_CheckIncomingMessages_should_handle_redundant_ADD_SOCKET_c
 
     ListenerTask_ReleaseMsg_Expect(l, msg);
     ListenerCmd_CheckIncomingMessages(l, &res);
-    
+
     TEST_ASSERT_EQUAL(0, res);
 }
 
@@ -149,7 +149,7 @@ static void setup_command(listener_msg *pmsg, rx_info_t *info) {
     if (pmsg->type == MSG_ADD_SOCKET) {
         ListenerTask_GrowReadBuf_ExpectAndReturn(l, 31, true);
     }
-    
+
     if (info) {
         ListenerHelper_GetFreeRXInfo_ExpectAndReturn(l, info == NULL_INFO ? NULL : info);
     }
@@ -244,7 +244,7 @@ void test_ListenerCmd_CheckIncomingMessages_should_handle_incoming_REMOVE_SOCKET
     l->fds[0 + INCOMING_MSG_PIPE].events = POLLIN;
     connection_info *ci0 = calloc(1, sizeof(*ci0));
     l->fd_info[0] = ci0;
-    
+
     int res = 1;
     ListenerTask_ReleaseMsg_Expect(l, &l->msgs[0]);
     ListenerCmd_CheckIncomingMessages(l, &res);
@@ -272,7 +272,7 @@ void test_ListenerCmd_CheckIncomingMessages_should_handle_incoming_REMOVE_SOCKET
     l->fds[0 + INCOMING_MSG_PIPE].events = 0;  // no POLLIN -> inactive
     connection_info *ci0 = calloc(1, sizeof(*ci0));
     l->fd_info[0] = ci0;
-    
+
     int res = 1;
     ListenerTask_ReleaseMsg_Expect(l, &l->msgs[0]);
     ListenerCmd_CheckIncomingMessages(l, &res);
@@ -305,7 +305,7 @@ void test_ListenerCmd_CheckIncomingMessages_should_handle_incoming_REMOVE_SOCKET
     l->fds[1 + INCOMING_MSG_PIPE].events = POLLIN;
     connection_info *ci1 = calloc(1, sizeof(*ci1));
     l->fd_info[1] = ci1;
-    
+
     int res = 1;
     ListenerTask_ReleaseMsg_Expect(l, &l->msgs[0]);
     ListenerCmd_CheckIncomingMessages(l, &res);
@@ -339,7 +339,7 @@ void test_ListenerCmd_CheckIncomingMessages_should_handle_incoming_REMOVE_SOCKET
     l->fds[1 + INCOMING_MSG_PIPE].events = POLLIN;
     connection_info *ci1 = calloc(1, sizeof(*ci1));
     l->fd_info[1] = ci1;
-    
+
     int res = 1;
     ListenerTask_ReleaseMsg_Expect(l, &l->msgs[0]);
     ListenerCmd_CheckIncomingMessages(l, &res);
@@ -571,7 +571,7 @@ void test_ListenerCmd_CheckIncomingMessages_should_immediately_fail_incoming_EXP
     TEST_ASSERT_EQUAL(RIS_EXPECT, hold_info.state);
     TEST_ASSERT_EQUAL(box, hold_info.u.expect.box);
     TEST_ASSERT_EQUAL(RX_ERROR_POLLHUP, hold_info.u.expect.error);
-    
+
 }
 
 void test_ListenerCmd_CheckIncomingMessages_should_handle_incoming_EXPECT_command_when_no_result_is_saved(void) {
@@ -604,7 +604,7 @@ void test_ListenerCmd_CheckIncomingMessages_should_handle_incoming_EXPECT_comman
     TEST_ASSERT_EQUAL(false, hold_info.u.expect.has_result);
     TEST_ASSERT_EQUAL(11, hold_info.timeout_sec);
 }
-    
+
 void test_ListenerCmd_CheckIncomingMessages_should_handle_incoming_SHUTDOWN_command(void) {
     listener_msg msg = {
         .id = 1,

--- a/test/unit/test_bus_listener_helper.c
+++ b/test/unit/test_bus_listener_helper.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "unity.h"
 #include "listener_helper.h"
 #include "listener_internal.h"

--- a/test/unit/test_bus_listener_helper.c
+++ b/test/unit/test_bus_listener_helper.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -103,7 +103,7 @@ void test_ListenerHelper_PushMessage_should_add_a_message_to_the_listeners_comma
     msg->pipes[0] = 23;
 
     syscall_write_ExpectAndReturn(l->commit_pipe, msg_buf, sizeof(msg_buf), sizeof(msg_buf));
-    
+
     int reply_fd = -1;
     TEST_ASSERT_TRUE(ListenerHelper_PushMessage(l, msg, &reply_fd));
     TEST_ASSERT_EQUAL(23, reply_fd);
@@ -119,7 +119,7 @@ void test_ListenerHelper_PushMessage_should_retry_and_add_a_message_to_the_liste
     errno = EINTR;
     syscall_write_ExpectAndReturn(l->commit_pipe, msg_buf, sizeof(msg_buf), -1);
     syscall_write_ExpectAndReturn(l->commit_pipe, msg_buf, sizeof(msg_buf), sizeof(msg_buf));
-    
+
     int reply_fd = -1;
     TEST_ASSERT_TRUE(ListenerHelper_PushMessage(l, msg, &reply_fd));
     TEST_ASSERT_EQUAL(23, reply_fd);
@@ -134,7 +134,7 @@ void test_ListenerHelper_PushMessage_should_expose_errors(void)
 
     errno = EIO;
     syscall_write_ExpectAndReturn(l->commit_pipe, msg_buf, sizeof(msg_buf), -1);
-    
+
     int reply_fd = -1;
     ListenerTask_ReleaseMsg_Expect(l, msg);
     TEST_ASSERT_FALSE(ListenerHelper_PushMessage(l, msg, &reply_fd));

--- a/test/unit/test_bus_listener_io.c
+++ b/test/unit/test_bus_listener_io.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "unity.h"
 #include "listener_io.h"
 #include "listener_internal.h"

--- a/test/unit/test_bus_listener_io.c
+++ b/test/unit/test_bus_listener_io.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -101,7 +101,7 @@ void test_ListenerIO_AttemptRecv_should_handle_hangups_single_fd(void) {
     l->rx_info_max_used = 1;
 
     ListenerIO_AttemptRecv(l, 1);
-    
+
     // socket with error (5) should get moved to end
     TEST_ASSERT_EQUAL(5, l->fds[0 + INCOMING_MSG_PIPE].fd);
     TEST_ASSERT_EQUAL(1, l->inactive_fds);
@@ -145,7 +145,7 @@ void test_ListenerIO_AttemptRecv_should_handle_hangups(void) {
     l->rx_info_max_used = 2;
 
     ListenerIO_AttemptRecv(l, 1);
-    
+
     // socket with error (5) should get moved to end
     TEST_ASSERT_EQUAL(100, l->fds[0 + INCOMING_MSG_PIPE].fd);
     TEST_ASSERT_EQUAL(5, l->fds[1 + INCOMING_MSG_PIPE].fd);
@@ -196,8 +196,8 @@ void test_ListenerIO_AttemptRecv_should_handle_socket_errors(void) {
     TEST_ASSERT_EQUAL(100, l->fds[0 + INCOMING_MSG_PIPE].fd);
     TEST_ASSERT_EQUAL(5, l->fds[1 + INCOMING_MSG_PIPE].fd);
 
-    TEST_ASSERT_EQUAL(1, l->inactive_fds);    
-    
+    TEST_ASSERT_EQUAL(1, l->inactive_fds);
+
     // should no longer attempt to read socket; timeout will close it
     TEST_ASSERT_EQUAL(0, l->fds[1 + INCOMING_MSG_PIPE].events);
 
@@ -275,20 +275,20 @@ void test_ListenerIO_AttemptRecv_should_handle_successful_socket_read_and_unpack
 
     l->read_buf = calloc(256, sizeof(uint8_t));
     l->read_buf_size = 256;
-    
+
     rx_info_t *info = &l->rx_info[0];
     info->state = RIS_EXPECT;
     box->fd = 5;
     info->u.expect.box = box;
 
     syscall_read_ExpectAndReturn(ci.fd, l->read_buf, ci.to_read_size, ci.to_read_size);
-    
+
     rx_info_t unpack_res_info = {
         .state = RIS_EXPECT,
     };
     ListenerHelper_FindInfoBySequenceID_ExpectAndReturn(l, ci.fd, 12345, &unpack_res_info);
     ListenerTask_AttemptDelivery_Expect(l, &unpack_res_info);
-    
+
     ListenerIO_AttemptRecv(l, 1);
 
     TEST_ASSERT_EQUAL(RX_ERROR_READY_FOR_DELIVERY, unpack_res_info.u.expect.error);
@@ -317,13 +317,13 @@ void test_ListenerIO_AttemptRecv_should_handle_successful_socket_read_and_unpack
 
     l->read_buf = calloc(256, sizeof(uint8_t));
     l->read_buf_size = 256;
-    
+
     rx_info_t *info = &l->rx_info[0];
     info->state = RIS_HOLD;
     box->fd = 5;
 
     syscall_read_ExpectAndReturn(ci.fd, l->read_buf, ci.to_read_size, ci.to_read_size);
-    
+
     rx_info_t unpack_res_info = {
         .state = RIS_HOLD,
     };
@@ -356,7 +356,7 @@ void test_ListenerIO_AttemptRecv_should_handle_successful_socket_read_and_unpack
 
     l->read_buf = calloc(256, sizeof(uint8_t));
     l->read_buf_size = 256;
-    
+
     rx_info_t *info = &l->rx_info[0];
     info->state = RIS_EXPECT;
     box->fd = 5;
@@ -370,7 +370,7 @@ void test_ListenerIO_AttemptRecv_should_handle_successful_socket_read_and_unpack
     };
     ListenerHelper_FindInfoBySequenceID_ExpectAndReturn(l, ci.fd, 12345, &unpack_res_info);
     ListenerTask_AttemptDelivery_Expect(l, &unpack_res_info);
-    
+
     ListenerIO_AttemptRecv(l, 1);
 
     TEST_ASSERT_EQUAL(RX_ERROR_READY_FOR_DELIVERY, unpack_res_info.u.expect.error);
@@ -399,7 +399,7 @@ void test_ListenerIO_AttemptRecv_should_handle_successful_socket_read_and_unpack
 
     l->read_buf = calloc(256, sizeof(uint8_t));
     l->read_buf_size = 256;
-    
+
     rx_info_t *info = &l->rx_info[0];
     info->state = RIS_EXPECT;
     box->fd = 5;
@@ -410,13 +410,13 @@ void test_ListenerIO_AttemptRecv_should_handle_successful_socket_read_and_unpack
     Util_IsResumableIOError_ExpectAndReturn(EINTR, true);
 
     syscall_read_ExpectAndReturn(ci.fd, l->read_buf, ci.to_read_size, ci.to_read_size);
-    
+
     rx_info_t unpack_res_info = {
         .state = RIS_EXPECT,
     };
     ListenerHelper_FindInfoBySequenceID_ExpectAndReturn(l, ci.fd, 12345, &unpack_res_info);
     ListenerTask_AttemptDelivery_Expect(l, &unpack_res_info);
-    
+
     ListenerIO_AttemptRecv(l, 1);
 
     TEST_ASSERT_EQUAL(RX_ERROR_READY_FOR_DELIVERY, unpack_res_info.u.expect.error);
@@ -446,7 +446,7 @@ void test_ListenerIO_AttemptRecv_should_handle_socket_hangup_during_read(void) {
 
     l->read_buf = calloc(256, sizeof(uint8_t));
     l->read_buf_size = 256;
-    
+
     rx_info_t *info = &l->rx_info[0];
     info->state = RIS_EXPECT;
     box->fd = 5;
@@ -483,20 +483,20 @@ void test_ListenerIO_AttemptRecv_should_handle_successful_socket_read_and_unpack
 
     l->read_buf = calloc(256, sizeof(uint8_t));
     l->read_buf_size = 256;
-    
+
     rx_info_t *info = &l->rx_info[0];
     info->state = RIS_EXPECT;
     box->fd = 5;
     info->u.expect.box = box;
 
     syscall_SSL_read_ExpectAndReturn(ci.ssl, l->read_buf, ci.to_read_size, ci.to_read_size);
-    
+
     rx_info_t unpack_res_info = {
         .state = RIS_EXPECT,
     };
     ListenerHelper_FindInfoBySequenceID_ExpectAndReturn(l, ci.fd, 12345, &unpack_res_info);
     ListenerTask_AttemptDelivery_Expect(l, &unpack_res_info);
-    
+
     ListenerIO_AttemptRecv(l, 1);
 
     TEST_ASSERT_EQUAL(RX_ERROR_READY_FOR_DELIVERY, unpack_res_info.u.expect.error);
@@ -527,7 +527,7 @@ void test_ListenerIO_AttemptRecv_should_handle_successful_socket_read_and_unpack
 
     l->read_buf = calloc(256, sizeof(uint8_t));
     l->read_buf_size = 256;
-    
+
     rx_info_t *info = &l->rx_info[0];
     info->state = RIS_EXPECT;
     box->fd = 5;
@@ -542,7 +542,7 @@ void test_ListenerIO_AttemptRecv_should_handle_successful_socket_read_and_unpack
     };
     ListenerHelper_FindInfoBySequenceID_ExpectAndReturn(l, ci.fd, 12345, &unpack_res_info);
     ListenerTask_AttemptDelivery_Expect(l, &unpack_res_info);
-    
+
     ListenerIO_AttemptRecv(l, 1);
 
     TEST_ASSERT_EQUAL(RX_ERROR_READY_FOR_DELIVERY, unpack_res_info.u.expect.error);

--- a/test/unit/test_bus_listener_task.c
+++ b/test/unit/test_bus_listener_task.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "unity.h"
 #include "listener_task.h"
 #include "listener_task_internal.h"

--- a/test/unit/test_bus_listener_task.c
+++ b/test/unit/test_bus_listener_task.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -314,7 +314,7 @@ void test_ListenerTask_MainLoop_should_check_commands(void) {
         -1, poll_res);
     ListenerCmd_CheckIncomingMessages_Expect(l, &poll_res);
     ListenerIO_AttemptRecv_Expect(l, poll_res);
-    
+
     ListenerTask_MainLoop((void *)l);
 }
 
@@ -343,7 +343,7 @@ void test_ListenerTask_GrowReadBuf_should_grow_the_listeners_read_buffer(void)
     TEST_ASSERT_EQUAL(200, l->read_buf_size);
     TEST_ASSERT(l->read_buf);
     memset(&l->read_buf[0], 0xFF, 200);  // write to notify valgrind
-    
+
     free(l->read_buf);
 }
 

--- a/test/unit/test_bus_poll.c
+++ b/test/unit/test_bus_poll.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "unity.h"
 #include "atomic.h"
 

--- a/test/unit/test_bus_poll.c
+++ b/test/unit/test_bus_poll.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -51,7 +51,7 @@ void tearDown(void) {
 void test_BusPoll_OnCompletion_should_return_true_on_successful_case(void)
 {
     syscall_poll_ExpectAndReturn(fds, 1, -1, 1);
-    
+
     fds[0].revents |= POLLIN;
 
     syscall_read_ExpectAndReturn(5, read_buf, sizeof(read_buf), sizeof(read_buf));
@@ -68,7 +68,7 @@ void test_BusPoll_OnCompletion_should_retry_on_EINTR(void)
     syscall_poll_ExpectAndReturn(fds, 1, -1, -1);
     poll_errno = EINTR;
     syscall_poll_ExpectAndReturn(fds, 1, -1, 1);
-    
+
     fds[0].revents |= POLLIN;
 
     syscall_read_ExpectAndReturn(5, read_buf, sizeof(read_buf), sizeof(read_buf));
@@ -90,7 +90,7 @@ void test_BusPoll_OnCompletion_should_expose_poll_IO_error(void)
 void test_BusPoll_OnCompletion_should_expose_POLLHUP(void)
 {
     syscall_poll_ExpectAndReturn(fds, 1, -1, 1);
-    
+
     fds[0].revents |= POLLHUP;
 
     TEST_ASSERT_FALSE(BusPoll_OnCompletion(b, 5));
@@ -100,7 +100,7 @@ void test_BusPoll_OnCompletion_should_expose_POLLHUP(void)
 void test_BusPoll_OnCompletion_should_expose_POLLERR(void)
 {
     syscall_poll_ExpectAndReturn(fds, 1, -1, 1);
-    
+
     fds[0].revents |= POLLERR;
 
     TEST_ASSERT_FALSE(BusPoll_OnCompletion(b, 5));
@@ -110,7 +110,7 @@ void test_BusPoll_OnCompletion_should_expose_POLLERR(void)
 void test_BusPoll_OnCompletion_should_expose_POLLNVAL(void)
 {
     syscall_poll_ExpectAndReturn(fds, 1, -1, 1);
-    
+
     fds[0].revents |= POLLNVAL;
 
     TEST_ASSERT_FALSE(BusPoll_OnCompletion(b, 5));
@@ -120,14 +120,14 @@ void test_BusPoll_OnCompletion_should_expose_POLLNVAL(void)
 void test_BusPoll_OnCompletion_should_retry_on_read_EINTR(void)
 {
     syscall_poll_ExpectAndReturn(fds, 1, -1, 1);
-    
+
     fds[0].revents |= POLLIN;
 
     syscall_read_ExpectAndReturn(5, read_buf, sizeof(read_buf), -1);
     read_errno = EINTR;
 
     syscall_poll_ExpectAndReturn(fds, 1, -1, 1);
-    
+
     fds[0].revents |= POLLIN;
 
     syscall_read_ExpectAndReturn(5, read_buf, sizeof(read_buf), sizeof(read_buf));
@@ -143,7 +143,7 @@ void test_BusPoll_OnCompletion_should_retry_on_read_EINTR(void)
 void test_BusPoll_OnCompletion_should_expose_read_IO_error(void)
 {
     syscall_poll_ExpectAndReturn(fds, 1, -1, 1);
-    
+
     fds[0].revents |= POLLNVAL;
 
     read_errno = EIO;
@@ -153,7 +153,7 @@ void test_BusPoll_OnCompletion_should_expose_read_IO_error(void)
 void test_BusPoll_OnCompletion_should_handle_incorrect_read_size(void)
 {
     syscall_poll_ExpectAndReturn(fds, 1, -1, 1);
-    
+
     fds[0].revents |= POLLIN;
 
     syscall_read_ExpectAndReturn(5, read_buf, sizeof(read_buf), sizeof(read_buf) - 1);

--- a/test/unit/test_bus_send.c
+++ b/test/unit/test_bus_send.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "unity.h"
 #include "send.h"
 #include "send_internal.h"

--- a/test/unit/test_bus_send.c
+++ b/test/unit/test_bus_send.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -61,10 +61,10 @@ static boxed_msg Box = {
 void setUp(void) {
     memset(fds, 0, sizeof(fds));
     b = &B;
-    
+
     listeners[0] = &Listener;
     l = &Listener;
-    
+
     box = &Box;
 }
 

--- a/test/unit/test_bus_send_helper.c
+++ b/test/unit/test_bus_send_helper.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "unity.h"
 #include "send_helper.h"
 #include "send_internal.h"

--- a/test/unit/test_bus_send_helper.c
+++ b/test/unit/test_bus_send_helper.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -57,7 +57,7 @@ void setUp(void) {
     b = &B;
     box = &Box;
     l = &Listener;
-    
+
     backpressure = 0;
     memset(&done, 0, sizeof(done));
 }

--- a/test/unit/test_byte_array.c
+++ b/test/unit/test_byte_array.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "unity.h"
 #include "byte_array.h"
 #include <string.h>

--- a/test/unit/test_byte_array.c
+++ b/test/unit/test_byte_array.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -294,7 +294,7 @@ void test_ByteBuffer_CreateAndAppendFormattedCString_should_append_a_generated_C
     uint8_t data[1024];
     size_t len = sizeof(data);
     memset(data, 0, len);
-    ByteBuffer buffer = 
+    ByteBuffer buffer =
         ByteBuffer_CreateAndAppendFormattedCString(data, sizeof(data),
             "Stuff: value=%d desc='%s'", 12, "foo");
     TEST_ASSERT_EQUAL_PTR(data, buffer.array.data);
@@ -309,7 +309,7 @@ void test_ByteBuffer_CreateAndAppendFormattedCString_should_return_NULL_if_forma
     uint8_t data[39];
     size_t len = sizeof(data);
     memset(data, 0, len);
-    ByteBuffer buffer = 
+    ByteBuffer buffer =
         ByteBuffer_CreateAndAppendFormattedCString(data, sizeof(data),
             "Stuff: value=%d desc='%s' fizzle=%0.4f", 12, "foo", 1.23456);
     TEST_ASSERT_EQUAL(0, buffer.bytesUsed);

--- a/test/unit/test_kinetic_acl.c
+++ b/test/unit/test_kinetic_acl.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "unity.h"
 #include "kinetic_acl.h"
 

--- a/test/unit/test_kinetic_acl.c
+++ b/test/unit/test_kinetic_acl.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -45,7 +45,7 @@ void test_acl_of_nonexistent_file_should_fail(void)
 void test_KineticACL_LoadFromFile_ex1_should_parse_file_as_expected(void)
 {
     struct ACL *acls = NULL;
-    
+
     KineticACLLoadResult res = KineticACL_LoadFromFile(TEST_DIR("ex1.json"), &acls);
     TEST_ASSERT_EQUAL(ACL_OK, res);
 
@@ -171,7 +171,7 @@ void test_KineticACL_LoadFromFile_should_handle_multiple_permissions(void)
     struct ACL *acls = NULL;
     KineticACLLoadResult res = KineticACL_LoadFromFile(TEST_DIR("ex-multi-permission.json"), &acls);
     TEST_ASSERT_EQUAL(ACL_OK, res);
-    
+
     Com__Seagate__Kinetic__Proto__Command__Security__ACL *acl = acls->ACLs[0];
 
     TEST_ASSERT_EQUAL(3, acl->scope[0]->n_permission);
@@ -187,7 +187,7 @@ void test_acl_should_handle_multiple_JSON_objects(void)
     struct ACL *acls = NULL;
     KineticACLLoadResult res = KineticACL_LoadFromFile(TEST_DIR("ex_multi.json"), &acls);
     TEST_ASSERT_EQUAL(ACL_OK, res);
-    
+
     Com__Seagate__Kinetic__Proto__Command__Security__ACL *acl = acls->ACLs[0];
     TEST_ASSERT_TRUE(acl->has_identity);
     TEST_ASSERT_EQUAL(1, acl->identity);

--- a/test/unit/test_kinetic_admin_client.c
+++ b/test/unit/test_kinetic_admin_client.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_admin_client_security.c
+++ b/test/unit/test_kinetic_admin_client_security.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_allocator.c
+++ b/test/unit/test_kinetic_allocator.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_auth.c
+++ b/test/unit/test_kinetic_auth.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_builder.c
+++ b/test/unit/test_kinetic_builder.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "unity_helper.h"
 #include "protobuf-c/protobuf-c.h"
 #include "byte_array.h"

--- a/test/unit/test_kinetic_builder.c
+++ b/test/unit/test_kinetic_builder.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -473,7 +473,7 @@ void test_KineticBuilder_BuildP2POperation_should_build_a_P2POperation_request(v
     TEST_ASSERT_EQUAL(COM__SEAGATE__KINETIC__PROTO__COMMAND__MESSAGE_TYPE__PEER2PEERPUSH,
         Request.message.command.header->messagetype);
     TEST_ASSERT_EQUAL_PTR(&Request.message.body, Request.command->body);
-    
+
     TEST_ASSERT_NOT_NULL(Request.command->body->p2poperation);
 
     TEST_ASSERT_EQUAL("hostname",
@@ -847,7 +847,7 @@ void test_KineticBuilder_BuildSetACL_should_build_a_SECURITY_operation(void)
         Request.message.command.header->messagetype);
     TEST_ASSERT_TRUE(Request.message.command.header->has_messagetype);
     TEST_ASSERT_EQUAL_PTR(&Request.message.body, Request.command->body);
-    
+
     TEST_ASSERT_FALSE(Request.command->body->security->has_oldlockpin);
     TEST_ASSERT_FALSE(Request.command->body->security->has_newlockpin);
     TEST_ASSERT_FALSE(Request.command->body->security->has_olderasepin);

--- a/test/unit/test_kinetic_bus.c
+++ b/test/unit/test_kinetic_bus.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -124,7 +124,7 @@ void test_sink_cb_should_reset_uninitialized_socket_state(void)
         .accumulated = 0xFFFFFFFF,
     };
     Session.si = si;
-    
+
     bus_sink_cb_res_t res = sink_cb(NULL, 0, &Session);
 
     TEST_ASSERT_EQUAL(0, si->accumulated);
@@ -151,7 +151,7 @@ void test_sink_cb_should_expose_invalid_header_error(void)
     TEST_ASSERT_EQUAL(sizeof(KineticPDUHeader), res.next_read);
     TEST_ASSERT_EQUAL(UNPACK_ERROR_INVALID_HEADER, si->unpack_status);
     TEST_ASSERT_EQUAL(si, res.full_msg_buffer);
-    
+
     TEST_ASSERT_EQUAL(0, si->accumulated);
     TEST_ASSERT_EQUAL(STATE_AWAITING_HEADER, si->state);
 }
@@ -200,7 +200,7 @@ void test_sink_cb_should_accumulate_partially_recieved_header(void)
     TEST_ASSERT_EQUAL(5, si->accumulated);
 
     res = sink_cb(read_buf2, sizeof(read_buf2), &Session);
-    
+
     TEST_ASSERT_EQUAL(123 + 456, res.next_read);
     TEST_ASSERT_EQUAL(NULL, res.full_msg_buffer);
     TEST_ASSERT_EQUAL(STATE_AWAITING_BODY, si->state);
@@ -253,7 +253,7 @@ void test_unpack_cb_should_expose_error_codes(void)
         .accumulated = 0,
         .unpack_status = UNPACK_ERROR_UNDEFINED,
     };
-    
+
     enum unpack_error error_states[] = {
         UNPACK_ERROR_UNDEFINED,
         UNPACK_ERROR_INVALID_HEADER,
@@ -279,7 +279,7 @@ void test_unpack_cb_should_expose_alloc_failure(void)
             .valueLength = 8,
         },
     };
-    
+
     KineticAllocator_NewKineticResponse_ExpectAndReturn(8, NULL);
     bus_unpack_cb_res_t res = unpack_cb((void*)&si, &Session);
     TEST_ASSERT_FALSE(res.ok);

--- a/test/unit/test_kinetic_callbacks.c
+++ b/test/unit/test_kinetic_callbacks.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "unity_helper.h"
 #include "protobuf-c/protobuf-c.h"
 #include "byte_array.h"

--- a/test/unit/test_kinetic_callbacks.c
+++ b/test/unit/test_kinetic_callbacks.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_client.c
+++ b/test/unit/test_kinetic_client.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_client_delete.c
+++ b/test/unit/test_kinetic_client_delete.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_client_flush.c
+++ b/test/unit/test_kinetic_client_flush.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -65,7 +65,7 @@ void test_KineticClient_flush_should_expose_memory_error_from_CreateOperation(vo
     KineticSession session;
 
     KineticAllocator_NewOperation_ExpectAndReturn(&session, NULL);
-    
+
     KineticStatus status = KineticClient_Flush(&session, NULL);
 
     TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_MEMORY_ERROR, status);

--- a/test/unit/test_kinetic_client_get.c
+++ b/test/unit/test_kinetic_client_get.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_client_get_key_range.c
+++ b/test/unit/test_kinetic_client_get_key_range.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_client_get_log.c
+++ b/test/unit/test_kinetic_client_get_log.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_client_getnext.c
+++ b/test/unit/test_kinetic_client_getnext.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_client_getprevious.c
+++ b/test/unit/test_kinetic_client_getprevious.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_client_noop.c
+++ b/test/unit/test_kinetic_client_noop.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_client_p2pop.c
+++ b/test/unit/test_kinetic_client_p2pop.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_client_put.c
+++ b/test/unit/test_kinetic_client_put.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -50,7 +50,7 @@ void test_KineticClient_Put_should_execute_PUT_operation(void)
     KineticEntry entry = {.value = ByteBuffer_CreateWithArray(value)};
     KineticOperation operation;
     operation.session = &Session;
-    
+
     KineticAllocator_NewOperation_ExpectAndReturn(&Session, &operation);
     KineticBuilder_BuildPut_ExpectAndReturn(&operation, &entry, KINETIC_STATUS_SUCCESS);
     KineticController_ExecuteOperation_ExpectAndReturn(&operation, NULL, KINETIC_STATUS_VERSION_MISMATCH);
@@ -67,7 +67,7 @@ void test_KineticClient_Put_should_allow_NULL_pointer_to_value_data_if_length_is
     KineticEntry entry = {.value = ByteBuffer_CreateWithArray(value)};
     KineticOperation operation;
     operation.session = &Session;
-    
+
     KineticAllocator_NewOperation_ExpectAndReturn(&Session, &operation);
     KineticBuilder_BuildPut_ExpectAndReturn(&operation, &entry, KINETIC_STATUS_SUCCESS);
     KineticController_ExecuteOperation_ExpectAndReturn(&operation, NULL, KINETIC_STATUS_VERSION_MISMATCH);
@@ -83,7 +83,7 @@ void test_KineticClient_Put_should_return_BUFFER_OVERRUN_if_object_value_too_lon
     KineticEntry entry = {.value = ByteBuffer_CreateWithArray(value)};
     KineticOperation operation;
     operation.session = &Session;
-    
+
     KineticAllocator_NewOperation_ExpectAndReturn(&Session, &operation);
 
     KineticBuilder_BuildPut_ExpectAndReturn(&operation, &entry, KINETIC_STATUS_BUFFER_OVERRUN);

--- a/test/unit/test_kinetic_controller.c
+++ b/test/unit/test_kinetic_controller.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_countingsemaphore.c
+++ b/test/unit/test_kinetic_countingsemaphore.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_device_info.c
+++ b/test/unit/test_kinetic_device_info.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -63,7 +63,7 @@ void test_KineticLogInfo_Create_should_allocate_and_populate_device_info_with_ut
     Com__Seagate__Kinetic__Proto__Command__GetLog getLog = COM__SEAGATE__KINETIC__PROTO__COMMAND__GET_LOG__INIT;
     getLog.n_utilizations = numUtilizations;
     char* names[] = {"fo", "shizzle"};
-    
+
     utilizations[0].name = names[0];
     utilizations[0].has_value = true;
     utilizations[0].value = 1.7f;

--- a/test/unit/test_kinetic_entry.c
+++ b/test/unit/test_kinetic_entry.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_hmac.c
+++ b/test/unit/test_kinetic_hmac.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_message.c
+++ b/test/unit/test_kinetic_message.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_nbo.c
+++ b/test/unit/test_kinetic_nbo.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_operation.c
+++ b/test/unit/test_kinetic_operation.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_request.c
+++ b/test/unit/test_kinetic_request.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_resourcewaiter.c
+++ b/test/unit/test_kinetic_resourcewaiter.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_response.c
+++ b/test/unit/test_kinetic_response.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -102,7 +102,7 @@ void test_KineticResponse_GetKeyRange_should_return_the_Com__Seagate__Kinetic__P
 
     range = KineticResponse_GetKeyRange(&Response);
     TEST_ASSERT_NULL(range);
-    
+
     Com__Seagate__Kinetic__Proto__Message Message;
     memset(&Message, 0, sizeof(Message));
     Response.proto = &Message;

--- a/test/unit/test_kinetic_session.c
+++ b/test/unit/test_kinetic_session.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information
@@ -55,7 +55,7 @@ void setUp(void)
     };
     Client.bus = &MessageBus;
     KineticCountingSemaphore_Create_ExpectAndReturn(KINETIC_MAX_OUTSTANDING_OPERATIONS_PER_SESSION, &Semaphore);
-    
+
     KineticStatus status = KineticSession_Create(&Session, &Client);
     TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
     TEST_ASSERT_FALSE(Session.connected);
@@ -91,8 +91,8 @@ void test_KineticSession_Create_should_allocate_and_destroy_KineticConnections(v
 
     KineticCountingSemaphore_Create_ExpectAndReturn(KINETIC_MAX_OUTSTANDING_OPERATIONS_PER_SESSION, &Semaphore);
 
-    KineticStatus status = KineticSession_Create(&session, &Client);    
-    
+    KineticStatus status = KineticSession_Create(&session, &Client);
+
     TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
     TEST_ASSERT_FALSE(session.connected);
     TEST_ASSERT_EQUAL(-1, session.socket);
@@ -103,7 +103,7 @@ void test_KineticSession_Create_should_allocate_and_destroy_KineticConnections(v
     KineticAllocator_FreeSession_Expect(&session);
 
     status = KineticSession_Destroy(&session);
-    
+
     TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
 }
 

--- a/test/unit/test_kinetic_types.c
+++ b/test/unit/test_kinetic_types.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_kinetic_types_internal.c
+++ b/test/unit/test_kinetic_types_internal.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/test/unit/test_yacht.c
+++ b/test/unit/test_yacht.c
@@ -14,6 +14,7 @@
  *
  * See www.openkinetic.org for more project information
  */
+
 #include "unity.h"
 #include "yacht.h"
 

--- a/test/unit/test_yacht.c
+++ b/test/unit/test_yacht.c
@@ -5,11 +5,11 @@
  * Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at
  * https://mozilla.org/MP:/2.0/.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
- * but is provided AS-IS, WITHOUT ANY WARRANTY; including without 
- * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public 
+ * but is provided AS-IS, WITHOUT ANY WARRANTY; including without
+ * the implied warranty of MERCHANTABILITY, NON-INFRINGEMENT or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public
  * License for more details.
  *
  * See www.openkinetic.org for more project information

--- a/vendor/protobuf-2.6.0/Makefile.in
+++ b/vendor/protobuf-2.6.0/Makefile.in
@@ -561,7 +561,7 @@ config.h: stamp-h1
 stamp-h1: $(srcdir)/config.h.in $(top_builddir)/config.status
 	@rm -f stamp-h1
 	cd $(top_builddir) && $(SHELL) ./config.status config.h
-$(srcdir)/config.h.in: @MAINTAINER_MODE_TRUE@ $(am__configure_deps) 
+$(srcdir)/config.h.in: @MAINTAINER_MODE_TRUE@ $(am__configure_deps)
 	($(am__cd) $(top_srcdir) && $(AUTOHEADER))
 	rm -f stamp-h1
 	touch $@

--- a/vendor/protobuf-2.6.0/editors/protobuf-mode.el
+++ b/vendor/protobuf-2.6.0/editors/protobuf-mode.el
@@ -69,7 +69,7 @@
   (require 'cc-langs)
   (require 'cc-fonts))
 
-;; This mode does not inherit properties from other modes. So, we do not use 
+;; This mode does not inherit properties from other modes. So, we do not use
 ;; the usual `c-add-language' function.
 (eval-and-compile
   (put 'protobuf-mode 'c-mode-prefix "protobuf-"))

--- a/vendor/protobuf-2.6.0/gtest/Makefile.in
+++ b/vendor/protobuf-2.6.0/gtest/Makefile.in
@@ -553,7 +553,7 @@ build-aux/config.h: build-aux/stamp-h1
 build-aux/stamp-h1: $(top_srcdir)/build-aux/config.h.in $(top_builddir)/config.status
 	@rm -f build-aux/stamp-h1
 	cd $(top_builddir) && $(SHELL) ./config.status build-aux/config.h
-$(top_srcdir)/build-aux/config.h.in:  $(am__configure_deps) 
+$(top_srcdir)/build-aux/config.h.in:  $(am__configure_deps)
 	($(am__cd) $(top_srcdir) && $(AUTOHEADER))
 	rm -f build-aux/stamp-h1
 	touch $@

--- a/vendor/protobuf-2.6.0/gtest/m4/acx_pthread.m4
+++ b/vendor/protobuf-2.6.0/gtest/m4/acx_pthread.m4
@@ -55,7 +55,7 @@ dnl @category InstalledPackages
 dnl @author Steven G. Johnson <stevenj@alum.mit.edu>
 dnl @version 2006-05-29
 dnl @license GPLWithACException
-dnl 
+dnl
 dnl Checks for GCC shared/pthread inconsistency based on work by
 dnl Marcin Owsiany <marcin@owsiany.pl>
 
@@ -240,14 +240,14 @@ if test "x$acx_pthread_ok" = xyes; then
 	# architectures and systems. The problem is that in certain
 	# configurations, when -shared is specified, GCC "forgets" to
 	# internally use various flags which are still necessary.
-	
+
 	#
 	# Prepare the flags
 	#
 	save_CFLAGS="$CFLAGS"
 	save_LIBS="$LIBS"
 	save_CC="$CC"
-	
+
 	# Try with the flags determined by the earlier checks.
 	#
 	# -Wl,-z,defs forces link-time symbol resolution, so that the
@@ -259,25 +259,25 @@ if test "x$acx_pthread_ok" = xyes; then
 	CFLAGS="-shared -fPIC -Wl,-z,defs $CFLAGS $PTHREAD_CFLAGS"
 	LIBS="$PTHREAD_LIBS $LIBS"
 	CC="$PTHREAD_CC"
-	
+
 	# In order not to create several levels of indentation, we test
 	# the value of "$done" until we find the cure or run out of ideas.
 	done="no"
-	
+
 	# First, make sure the CFLAGS we added are actually accepted by our
 	# compiler.  If not (and OS X's ld, for instance, does not accept -z),
 	# then we can't do this test.
 	if test x"$done" = xno; then
 	   AC_MSG_CHECKING([whether to check for GCC pthread/shared inconsistencies])
 	   AC_TRY_LINK(,, , [done=yes])
-	
+
 	   if test "x$done" = xyes ; then
 	      AC_MSG_RESULT([no])
 	   else
 	      AC_MSG_RESULT([yes])
 	   fi
 	fi
-	
+
 	if test x"$done" = xno; then
 	   AC_MSG_CHECKING([whether -pthread is sufficient with -shared])
 	   AC_TRY_LINK([#include <pthread.h>],
@@ -285,14 +285,14 @@ if test "x$acx_pthread_ok" = xyes; then
 	      pthread_attr_init(0); pthread_cleanup_push(0, 0);
 	      pthread_create(0,0,0,0); pthread_cleanup_pop(0); ],
 	      [done=yes])
-	   
+
 	   if test "x$done" = xyes; then
 	      AC_MSG_RESULT([yes])
 	   else
 	      AC_MSG_RESULT([no])
 	   fi
 	fi
-	
+
 	#
 	# Linux gcc on some architectures such as mips/mipsel forgets
 	# about -lpthread
@@ -305,7 +305,7 @@ if test "x$acx_pthread_ok" = xyes; then
 	      pthread_attr_init(0); pthread_cleanup_push(0, 0);
 	      pthread_create(0,0,0,0); pthread_cleanup_pop(0); ],
 	      [done=yes])
-	
+
 	   if test "x$done" = xyes; then
 	      AC_MSG_RESULT([yes])
 	      PTHREAD_LIBS="-lpthread $PTHREAD_LIBS"
@@ -324,7 +324,7 @@ if test "x$acx_pthread_ok" = xyes; then
 	        pthread_attr_init(0); pthread_cleanup_push(0, 0);
 	        pthread_create(0,0,0,0); pthread_cleanup_pop(0); ],
 	       [done=yes])
-	
+
 	   if test "x$done" = xyes; then
 	      AC_MSG_RESULT([yes])
 	      PTHREAD_LIBS="-lc_r $PTHREAD_LIBS"
@@ -335,11 +335,11 @@ if test "x$acx_pthread_ok" = xyes; then
 	if test x"$done" = xno; then
 	   # OK, we have run out of ideas
 	   AC_MSG_WARN([Impossible to determine how to use pthreads with shared libraries])
-	
+
 	   # so it's not safe to assume that we may use pthreads
 	   acx_pthread_ok=no
 	fi
-	
+
 	CFLAGS="$save_CFLAGS"
 	LIBS="$save_LIBS"
 	CC="$save_CC"

--- a/vendor/protobuf-2.6.0/gtest/m4/libtool.m4
+++ b/vendor/protobuf-2.6.0/gtest/m4/libtool.m4
@@ -1196,7 +1196,7 @@ fi
 # Invoke $ECHO with all args, space-separated.
 func_echo_all ()
 {
-    $ECHO "$*" 
+    $ECHO "$*"
 }
 
 case "$ECHO" in

--- a/vendor/protobuf-2.6.0/gtest/m4/lt~obsolete.m4
+++ b/vendor/protobuf-2.6.0/gtest/m4/lt~obsolete.m4
@@ -25,7 +25,7 @@
 # included after everything else.  This provides aclocal with the
 # AC_DEFUNs it wants, but when m4 processes it, it doesn't do anything
 # because those macros already exist, or will be overwritten later.
-# We use AC_DEFUN over AU_DEFUN for compatibility with aclocal-1.6. 
+# We use AC_DEFUN over AU_DEFUN for compatibility with aclocal-1.6.
 #
 # Anytime we withdraw an AC_DEFUN or AU_DEFUN, remember to add it here.
 # Yes, that means every name once taken will need to remain here until

--- a/vendor/protobuf-2.6.0/gtest/test/gtest_output_test_golden_lin.txt
+++ b/vendor/protobuf-2.6.0/gtest/test/gtest_output_test_golden_lin.txt
@@ -131,7 +131,7 @@ Value of: n
 Expected: 1
 Google Test trace:
 gtest_output_test_.cc:#: n = 2
-gtest_output_test_.cc:#: 
+gtest_output_test_.cc:#:
 [0;31m[  FAILED  ] [mSCOPED_TRACETest.CanBeNested
 [0;32m[ RUN      ] [mSCOPED_TRACETest.CanBeRepeated
 (expected to fail)

--- a/vendor/protobuf-2.6.0/gtest/xcode/Config/DebugProject.xcconfig
+++ b/vendor/protobuf-2.6.0/gtest/xcode/Config/DebugProject.xcconfig
@@ -6,7 +6,7 @@
 //  dialog.
 //  This file is based on the Xcode Configuration files in:
 //  http://code.google.com/p/google-toolbox-for-mac/
-// 
+//
 
 #include "General.xcconfig"
 

--- a/vendor/protobuf-2.6.0/gtest/xcode/Config/FrameworkTarget.xcconfig
+++ b/vendor/protobuf-2.6.0/gtest/xcode/Config/FrameworkTarget.xcconfig
@@ -5,7 +5,7 @@
 //  is set in the "Based On:" dropdown in the "Target" info dialog.
 //  This file is based on the Xcode Configuration files in:
 //  http://code.google.com/p/google-toolbox-for-mac/
-// 
+//
 
 // Dynamic libs need to be position independent
 GCC_DYNAMIC_NO_PIC = NO

--- a/vendor/protobuf-2.6.0/gtest/xcode/Config/General.xcconfig
+++ b/vendor/protobuf-2.6.0/gtest/xcode/Config/General.xcconfig
@@ -5,7 +5,7 @@
 //  examples.
 //  This file is based on the Xcode Configuration files in:
 //  http://code.google.com/p/google-toolbox-for-mac/
-// 
+//
 
 // Build for PPC and Intel, 32- and 64-bit
 ARCHS = i386 x86_64 ppc ppc64

--- a/vendor/protobuf-2.6.0/gtest/xcode/Config/ReleaseProject.xcconfig
+++ b/vendor/protobuf-2.6.0/gtest/xcode/Config/ReleaseProject.xcconfig
@@ -6,7 +6,7 @@
 //  dialog.
 //  This file is based on the Xcode Configuration files in:
 //  http://code.google.com/p/google-toolbox-for-mac/
-// 
+//
 
 #include "General.xcconfig"
 

--- a/vendor/protobuf-2.6.0/gtest/xcode/Config/StaticLibraryTarget.xcconfig
+++ b/vendor/protobuf-2.6.0/gtest/xcode/Config/StaticLibraryTarget.xcconfig
@@ -5,7 +5,7 @@
 //  is set in the "Based On:" dropdown in the "Target" info dialog.
 //  This file is based on the Xcode Configuration files in:
 //  http://code.google.com/p/google-toolbox-for-mac/
-// 
+//
 
 // Static libs can be included in bundles so make them position independent
 GCC_DYNAMIC_NO_PIC = NO

--- a/vendor/protobuf-2.6.0/gtest/xcode/Scripts/runtests.sh
+++ b/vendor/protobuf-2.6.0/gtest/xcode/Scripts/runtests.sh
@@ -41,7 +41,7 @@ test_executables=("$BUILT_PRODUCTS_DIR/gtest_unittest-framework"
                   "$BUILT_PRODUCTS_DIR/sample1_unittest-framework"
                   "$BUILT_PRODUCTS_DIR/sample1_unittest-static")
 
-# Now execute each one in turn keeping track of how many succeeded and failed. 
+# Now execute each one in turn keeping track of how many succeeded and failed.
 succeeded=0
 failed=0
 failed_list=()

--- a/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/AbstractMessage.java
+++ b/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/AbstractMessage.java
@@ -123,7 +123,7 @@ public abstract class AbstractMessage extends AbstractMessageLite
     }
     return hash;
   }
-  
+
   private static ByteString toByteString(Object value) {
     if (value instanceof byte[]) {
       return ByteString.copyFrom((byte[]) value);
@@ -131,7 +131,7 @@ public abstract class AbstractMessage extends AbstractMessageLite
       return (ByteString) value;
     }
   }
- 
+
   /**
    * Compares two bytes fields. The parameters must be either a byte array or a
    * ByteString object. They can be of different type though.
@@ -142,7 +142,7 @@ public abstract class AbstractMessage extends AbstractMessageLite
     }
     return toByteString(a).equals(toByteString(b));
   }
-  
+
   /**
    * Compares two set of fields.
    * This method is used to implement {@link AbstractMessage#equals(Object)}

--- a/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/BoundedByteString.java
+++ b/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/BoundedByteString.java
@@ -116,7 +116,7 @@ class BoundedByteString extends LiteralByteString {
   // ByteString -> byte[]
 
   @Override
-  protected void copyToInternal(byte[] target, int sourceOffset, 
+  protected void copyToInternal(byte[] target, int sourceOffset,
       int targetOffset, int numberToCopy) {
     System.arraycopy(bytes, getOffsetIntoBytes() + sourceOffset, target,
         targetOffset, numberToCopy);

--- a/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/ByteString.java
+++ b/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/ByteString.java
@@ -503,7 +503,7 @@ public abstract class ByteString implements Iterable<Byte> {
   /**
    * Internal (package private) implementation of
    * @link{#copyTo(byte[],int,int,int}.
-   * It assumes that all error checking has already been performed and that 
+   * It assumes that all error checking has already been performed and that
    * @code{numberToCopy > 0}.
    */
   protected abstract void copyToInternal(byte[] target, int sourceOffset,
@@ -542,7 +542,7 @@ public abstract class ByteString implements Iterable<Byte> {
    * @throws IOException  if an I/O error occurs.
    */
   public abstract void writeTo(OutputStream out) throws IOException;
-  
+
   /**
    * Writes a specified part of this byte string to an output stream.
    *
@@ -568,7 +568,7 @@ public abstract class ByteString implements Iterable<Byte> {
     if (numberToWrite > 0) {
       writeToInternal(out, sourceOffset, numberToWrite);
     }
-    
+
   }
 
   /**
@@ -595,7 +595,7 @@ public abstract class ByteString implements Iterable<Byte> {
    * <p>
    * By returning a list, implementations of this method may be able to avoid
    * copying even when there are multiple backing arrays.
-   * 
+   *
    * @return a list of wrapped bytes
    */
   public abstract List<ByteBuffer> asReadOnlyByteBufferList();
@@ -827,7 +827,7 @@ public abstract class ByteString implements Iterable<Byte> {
       flushLastBuffer();
       return ByteString.copyFrom(flushedBuffers);
     }
-    
+
     /**
      * Implement java.util.Arrays.copyOf() for jdk 1.5.
      */

--- a/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/CodedOutputStream.java
+++ b/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/CodedOutputStream.java
@@ -144,7 +144,7 @@ public final class CodedOutputStream {
       int bufferSize) {
     return newInstance(new ByteBufferOutputStream(byteBuffer), bufferSize);
   }
-  
+
   private static class ByteBufferOutputStream extends OutputStream {
     private final ByteBuffer byteBuffer;
     public ByteBufferOutputStream(ByteBuffer byteBuffer) {
@@ -750,7 +750,7 @@ public final class CodedOutputStream {
            computeUInt32Size(WireFormat.MESSAGE_SET_TYPE_ID, fieldNumber) +
            computeLazyFieldSize(WireFormat.MESSAGE_SET_MESSAGE, value);
   }
-  
+
   // -----------------------------------------------------------------
 
   /**

--- a/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/Descriptors.java
+++ b/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/Descriptors.java
@@ -234,7 +234,7 @@ public final class Descriptors {
                                     throws DescriptorValidationException {
       return buildFrom(proto, dependencies, false);
     }
-    
+
 
     /**
      * Construct a {@code FileDescriptor}.
@@ -473,9 +473,9 @@ public final class Descriptors {
           proto.getExtension(i), this, null, i, true);
       }
     }
-    
+
     /**
-     * Create a placeholder FileDescriptor for a message Descriptor. 
+     * Create a placeholder FileDescriptor for a message Descriptor.
      */
     FileDescriptor(String packageName, Descriptor message)
         throws DescriptorValidationException {
@@ -719,7 +719,7 @@ public final class Descriptors {
       this.fields = new FieldDescriptor[0];
       this.extensions = new FieldDescriptor[0];
       this.oneofs = new OneofDescriptor[0];
-      
+
       // Create a placeholder FileDescriptor to hold this message.
       this.file = new FileDescriptor(packageName, this);
     }
@@ -1297,8 +1297,8 @@ public final class Descriptors {
                 "Message type had default value.");
           }
         } catch (NumberFormatException e) {
-          throw new DescriptorValidationException(this, 
-              "Could not parse default value: \"" + 
+          throw new DescriptorValidationException(this,
+              "Could not parse default value: \"" +
               proto.getDefaultValue() + '\"', e);
         }
       } else {
@@ -1489,7 +1489,7 @@ public final class Descriptors {
 
     /** Get the value's number. */
     public int getNumber() { return proto.getNumber(); }
-    
+
     @Override
     public String toString() { return proto.getName(); }
 
@@ -1815,13 +1815,13 @@ public final class Descriptors {
    * descriptors defined in a particular file.
    */
   private static final class DescriptorPool {
-    
-    /** Defines what subclass of descriptors to search in the descriptor pool. 
+
+    /** Defines what subclass of descriptors to search in the descriptor pool.
      */
     enum SearchFilter {
       TYPES_ONLY, AGGREGATES_ONLY, ALL_SYMBOLS
     }
-    
+
     DescriptorPool(final FileDescriptor[] dependencies,
         boolean allowUnknownDependencies) {
       this.dependencies = new HashSet<FileDescriptor>();
@@ -1867,9 +1867,9 @@ public final class Descriptors {
     GenericDescriptor findSymbol(final String fullName) {
       return findSymbol(fullName, SearchFilter.ALL_SYMBOLS);
     }
-    
-    /** Find a descriptor by fully-qualified name and given option to only 
-     * search valid field type descriptors. 
+
+    /** Find a descriptor by fully-qualified name and given option to only
+     * search valid field type descriptors.
      */
     GenericDescriptor findSymbol(final String fullName,
                                  final SearchFilter filter) {
@@ -1898,18 +1898,18 @@ public final class Descriptors {
 
     /** Checks if the descriptor is a valid type for a message field. */
     boolean isType(GenericDescriptor descriptor) {
-      return (descriptor instanceof Descriptor) || 
+      return (descriptor instanceof Descriptor) ||
         (descriptor instanceof EnumDescriptor);
     }
-    
+
     /** Checks if the descriptor is a valid namespace type. */
     boolean isAggregate(GenericDescriptor descriptor) {
-      return (descriptor instanceof Descriptor) || 
-        (descriptor instanceof EnumDescriptor) || 
-        (descriptor instanceof PackageDescriptor) || 
+      return (descriptor instanceof Descriptor) ||
+        (descriptor instanceof EnumDescriptor) ||
+        (descriptor instanceof PackageDescriptor) ||
         (descriptor instanceof ServiceDescriptor);
     }
-       
+
     /**
      * Look up a type descriptor by name, relative to some other descriptor.
      * The name may be fully-qualified (with a leading '.'),
@@ -1967,7 +1967,7 @@ public final class Descriptors {
 
             // Append firstPart and try to find
             scopeToTry.append(firstPart);
-            result = findSymbol(scopeToTry.toString(), 
+            result = findSymbol(scopeToTry.toString(),
                 DescriptorPool.SearchFilter.AGGREGATES_ONLY);
 
             if (result != null) {

--- a/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/Extension.java
+++ b/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/Extension.java
@@ -80,7 +80,7 @@ public abstract class Extension<ContainingType extends MessageLite, Type> {
     PROTO1,
     PROTO2,
   }
-  
+
   /**
    * If the extension is a message extension (i.e., getLiteType() == MESSAGE),
    * returns the type of the message, otherwise undefined.

--- a/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/FieldSet.java
+++ b/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/FieldSet.java
@@ -474,7 +474,7 @@ final class FieldSet<FieldDescriptorType extends
   }
 
   /**
-   * Like {@link Message.Builder#mergeFrom(Message)}, but merges from another 
+   * Like {@link Message.Builder#mergeFrom(Message)}, but merges from another
    * {@link FieldSet}.
    */
   public void mergeFrom(final FieldSet<FieldDescriptorType> other) {

--- a/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/GeneratedMessage.java
+++ b/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/GeneratedMessage.java
@@ -1256,7 +1256,7 @@ public abstract class GeneratedMessage extends AbstractMessage
       implements ExtensionDescriptorRetriever {
     private volatile FieldDescriptor descriptor;
     protected abstract FieldDescriptor loadDescriptor();
-    
+
     public FieldDescriptor getDescriptor() {
       if (descriptor == null) {
         synchronized (this) {
@@ -1799,7 +1799,7 @@ public abstract class GeneratedMessage extends AbstractMessage
         invokeOrDie(clearMethod, builder);
       }
     }
-    
+
     private static boolean supportFieldPresence(FileDescriptor file) {
       return true;
     }
@@ -1846,11 +1846,11 @@ public abstract class GeneratedMessage extends AbstractMessage
       protected final FieldDescriptor field;
       protected final boolean isOneofField;
       protected final boolean hasHasMethod;
-      
+
       private int getOneofFieldNumber(final GeneratedMessage message) {
         return ((Internal.EnumLite) invokeOrDie(caseMethod, message)).getNumber();
       }
-      
+
       private int getOneofFieldNumber(final GeneratedMessage.Builder builder) {
         return ((Internal.EnumLite) invokeOrDie(caseMethodBuilder, builder)).getNumber();
       }

--- a/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/Internal.java
+++ b/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/Internal.java
@@ -106,7 +106,7 @@ public class Internal {
    * Helper called by generated code to construct default values for bytes
    * fields.
    * <p>
-   * This is like {@link #bytesDefaultValue}, but returns a byte array. 
+   * This is like {@link #bytesDefaultValue}, but returns a byte array.
    */
   public static byte[] byteArrayDefaultValue(String bytes) {
     try {
@@ -123,7 +123,7 @@ public class Internal {
    * Helper called by generated code to construct default values for bytes
    * fields.
    * <p>
-   * This is like {@link #bytesDefaultValue}, but returns a ByteBuffer. 
+   * This is like {@link #bytesDefaultValue}, but returns a ByteBuffer.
    */
   public static ByteBuffer byteBufferDefaultValue(String bytes) {
     return ByteBuffer.wrap(byteArrayDefaultValue(bytes));
@@ -179,7 +179,7 @@ public class Internal {
   public static boolean isValidUtf8(ByteString byteString) {
     return byteString.isValidUtf8();
   }
-  
+
   /**
    * Like {@link #isValidUtf8(ByteString)} but for byte arrays.
    */
@@ -197,7 +197,7 @@ public class Internal {
       throw new RuntimeException("UTF-8 not supported?", e);
     }
   }
-  
+
   /**
    * Helper method to convert a byte array to a string using UTF-8 encoding.
    */
@@ -268,7 +268,7 @@ public class Internal {
     }
     return hash;
   }
-  
+
   /**
    * Helper method for implementing {@link MessageLite#equals()} for bytes field.
    */
@@ -292,7 +292,7 @@ public class Internal {
     }
     return hash;
   }
-  
+
   /**
    * Helper method for implementing {@link MessageLite#hashCode()} for bytes field.
    */
@@ -303,7 +303,7 @@ public class Internal {
     // based hashCode() method.
     return LiteralByteString.hashCode(bytes);
   }
-  
+
   /**
    * Helper method for implementing {@link MessageLite#equals()} for bytes
    * field.
@@ -316,7 +316,7 @@ public class Internal {
     // compare all the content.
     return a.duplicate().clear().equals(b.duplicate().clear());
   }
-  
+
   /**
    * Helper method for implementing {@link MessageLite#equals()} for bytes
    * field.
@@ -345,9 +345,9 @@ public class Internal {
     }
     return hash;
   }
-  
+
   private static final int DEFAULT_BUFFER_SIZE = 4096;
-  
+
   /**
    * Helper method for implementing {@link MessageLite#hashCode()} for bytes
    * field.
@@ -376,12 +376,12 @@ public class Internal {
       return h == 0 ? 1 : h;
     }
   }
-  
+
   /**
    * An empty byte array constant used in generated code.
    */
   public static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
-  
+
   /**
    * An empty byte array constant used in generated code.
    */

--- a/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/LazyStringArrayList.java
+++ b/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/LazyStringArrayList.java
@@ -174,7 +174,7 @@ public class LazyStringArrayList extends AbstractList<String>
     list.add(element);
     modCount++;
   }
-  
+
   // @Override
   public void add(byte[] element) {
     list.add(element);
@@ -190,7 +190,7 @@ public class LazyStringArrayList extends AbstractList<String>
     }
     return b;
   }
-  
+
   // @Override
   public byte[] getByteArray(int index) {
     Object o = list.get(index);
@@ -221,7 +221,7 @@ public class LazyStringArrayList extends AbstractList<String>
       return Internal.toStringUtf8((byte[]) o);
     }
   }
-  
+
   private static ByteString asByteString(Object o) {
     if (o instanceof ByteString) {
       return (ByteString) o;
@@ -231,7 +231,7 @@ public class LazyStringArrayList extends AbstractList<String>
       return ByteString.copyFrom((byte[]) o);
     }
   }
-  
+
   private static byte[] asByteArray(Object o) {
     if (o instanceof byte[]) {
       return (byte[]) o;
@@ -264,11 +264,11 @@ public class LazyStringArrayList extends AbstractList<String>
   private static class ByteArrayListView extends AbstractList<byte[]>
       implements RandomAccess {
     private final List<Object> list;
-    
+
     ByteArrayListView(List<Object> list) {
       this.list = list;
     }
-    
+
     @Override
     public byte[] get(int index) {
       Object o = list.get(index);
@@ -304,7 +304,7 @@ public class LazyStringArrayList extends AbstractList<String>
       return asByteArray(o);
     }
   }
-  
+
   // @Override
   public List<byte[]> asByteArrayList() {
     return new ByteArrayListView(list);

--- a/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/LazyStringList.java
+++ b/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/LazyStringList.java
@@ -56,7 +56,7 @@ public interface LazyStringList extends ProtocolStringList {
    *         ({@code index < 0 || index >= size()})
    */
   ByteString getByteString(int index);
-  
+
   /**
    * Returns the element at the specified position in this list as byte[].
    *
@@ -99,7 +99,7 @@ public interface LazyStringList extends ProtocolStringList {
    *         ({@code index < 0 || index >= size()})
    */
   void set(int index, ByteString element);
-  
+
   /**
    * Replaces the element at the specified position in this list with the
    * specified element (optional operation).

--- a/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/LiteralByteString.java
+++ b/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/LiteralByteString.java
@@ -110,7 +110,7 @@ class LiteralByteString extends ByteString {
   // ByteString -> byte[]
 
   @Override
-  protected void copyToInternal(byte[] target, int sourceOffset, 
+  protected void copyToInternal(byte[] target, int sourceOffset,
       int targetOffset, int numberToCopy) {
     // Optimized form, not for subclasses, since we don't call
     // getOffsetIntoBytes() or check the 'numberToCopy' parameter.
@@ -270,14 +270,14 @@ class LiteralByteString extends ByteString {
   protected int partialHash(int h, int offset, int length) {
     return hashCode(h, bytes, getOffsetIntoBytes() + offset, length);
   }
-  
+
   static int hashCode(int h, byte[] bytes, int offset, int length) {
     for (int i = offset; i < offset + length; i++) {
       h = h * 31 + bytes[i];
     }
     return h;
   }
-  
+
   static int hashCode(byte[] bytes) {
     int h = hashCode(bytes.length, bytes, 0, bytes.length);
     return h == 0 ? 1 : h;

--- a/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/MessageReflection.java
+++ b/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/MessageReflection.java
@@ -340,7 +340,7 @@ class MessageReflection {
         ByteString bytes, ExtensionRegistryLite registry,
         Descriptors.FieldDescriptor descriptor, Message defaultInstance)
         throws IOException;
-    
+
     /**
      * Read a primitive field from input. Note that builders and mutable
      * messages may use different Java types to represent a primtive field.
@@ -513,7 +513,7 @@ class MessageReflection {
         return new BuilderAdapter(builder.newBuilderForField(field));
       }
     }
-    
+
     public Object readPrimitiveField(
         CodedInputStream input, WireFormat.FieldType type,
         boolean checkUtf8) throws IOException {
@@ -651,7 +651,7 @@ class MessageReflection {
       throw new UnsupportedOperationException(
           "newMergeTargetForField() called on FieldSet object");
     }
-    
+
     public Object readPrimitiveField(
         CodedInputStream input, WireFormat.FieldType type,
         boolean checkUtf8) throws IOException {

--- a/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/UnknownFieldSet.java
+++ b/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/UnknownFieldSet.java
@@ -368,7 +368,7 @@ public final class UnknownFieldSet implements MessageLite {
       reinitialize();
       return this;
     }
-    
+
     /** Clear fields from the set with a given field number. */
     public Builder clearField(final int number) {
       if (number == 0) {

--- a/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/UnmodifiableLazyStringList.java
+++ b/vendor/protobuf-2.6.0/java/src/main/java/com/google/protobuf/UnmodifiableLazyStringList.java
@@ -92,7 +92,7 @@ public class UnmodifiableLazyStringList extends AbstractList<String>
   public void add(byte[] element) {
     throw new UnsupportedOperationException();
   }
-  
+
   //@Override (Java 1.6 override semantics, but we must support 1.5)
   public void set(int index, byte[] element) {
     throw new UnsupportedOperationException();

--- a/vendor/protobuf-2.6.0/java/src/test/java/com/google/protobuf/ByteStringTest.java
+++ b/vendor/protobuf-2.6.0/java/src/test/java/com/google/protobuf/ByteStringTest.java
@@ -380,7 +380,7 @@ public class ByteStringTest extends TestCase {
       return -1;
     }
   }
-  
+
   // A stream which exposes the byte array passed into write(byte[], int, int).
   private static class EvilOutputStream extends OutputStream {
     public byte[] capturedArray = null;
@@ -492,13 +492,13 @@ public class ByteStringTest extends TestCase {
           isArrayRange(bytes, byteString.toByteArray(), 0, bytes.length));
     }
   }
-  
+
   public void testNewOutputEmpty() throws IOException {
     // Make sure newOutput() correctly builds empty byte strings
     ByteString byteString = ByteString.newOutput().toByteString();
     assertEquals(ByteString.EMPTY, byteString);
   }
-  
+
   public void testNewOutput_Mutating() throws IOException {
     Output os = ByteString.newOutput(5);
     os.write(new byte[] {1, 2, 3, 4, 5});
@@ -705,14 +705,14 @@ public class ByteStringTest extends TestCase {
     }
     return pieces;
   }
-  
+
   private byte[] substringUsingWriteTo(
       ByteString data, int offset, int length) throws IOException {
     ByteArrayOutputStream output = new ByteArrayOutputStream();
     data.writeTo(output, offset, length);
     return output.toByteArray();
   }
-  
+
   public void testWriteToOutputStream() throws Exception {
     // Choose a size large enough so when two ByteStrings are concatenated they
     // won't be merged into one byte array due to some optimizations.
@@ -727,7 +727,7 @@ public class ByteStringTest extends TestCase {
     byte[] result = substringUsingWriteTo(left, 1, 1);
     assertEquals(1, result.length);
     assertEquals((byte) 11, result[0]);
-    
+
     byte[] data2 = new byte[dataSize];
     for (int i = 0; i < data1.length; i++) {
       data2[i] = (byte) 2;

--- a/vendor/protobuf-2.6.0/java/src/test/java/com/google/protobuf/CodedOutputStreamTest.java
+++ b/vendor/protobuf-2.6.0/java/src/test/java/com/google/protobuf/CodedOutputStreamTest.java
@@ -330,7 +330,7 @@ public class CodedOutputStreamTest extends TestCase {
     assertTrue(codedStream.getTotalBytesWritten() > BUFFER_SIZE);
     assertEquals(value.length * 1024, codedStream.getTotalBytesWritten());
   }
-  
+
   public void testWriteToByteBuffer() throws Exception {
     final int bufferSize = 16 * 1024;
     ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
@@ -351,7 +351,7 @@ public class CodedOutputStreamTest extends TestCase {
       codedStream.writeRawByte((byte) 3);
     }
     codedStream.flush();
-    
+
     // Check that data is correctly written to the ByteBuffer.
     assertEquals(0, buffer.remaining());
     buffer.flip();
@@ -365,7 +365,7 @@ public class CodedOutputStreamTest extends TestCase {
       assertEquals((byte) 3, buffer.get());
     }
   }
-  
+
   public void testWriteByteBuffer() throws Exception {
     byte[] value = "abcde".getBytes("UTF-8");
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
@@ -377,10 +377,10 @@ public class CodedOutputStreamTest extends TestCase {
     // The above call shouldn't affect the ByteBuffer's state.
     assertEquals(0, byteBuffer.position());
     assertEquals(1, byteBuffer.limit());
-    
+
     // The correct way to write part of an array using ByteBuffer.
     codedStream.writeRawBytes(ByteBuffer.wrap(value, 2, 1).slice());
-    
+
     codedStream.flush();
     byte[] result = outputStream.toByteArray();
     assertEquals(6, result.length);

--- a/vendor/protobuf-2.6.0/java/src/test/java/com/google/protobuf/DeprecatedFieldTest.java
+++ b/vendor/protobuf-2.6.0/java/src/test/java/com/google/protobuf/DeprecatedFieldTest.java
@@ -38,22 +38,22 @@ import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 /**
  * Test field deprecation
- * 
+ *
  * @author birdo@google.com (Roberto Scaramuzzi)
  */
 public class DeprecatedFieldTest extends TestCase {
   private String[] deprecatedGetterNames = {
       "hasDeprecatedInt32",
       "getDeprecatedInt32"};
-  
+
   private String[] deprecatedBuilderGetterNames = {
       "hasDeprecatedInt32",
       "getDeprecatedInt32",
       "clearDeprecatedInt32"};
-  
+
   private String[] deprecatedBuilderSetterNames = {
-      "setDeprecatedInt32"}; 
-  
+      "setDeprecatedInt32"};
+
   public void testDeprecatedField() throws Exception {
     Class<?> deprecatedFields = TestDeprecatedFields.class;
     Class<?> deprecatedFieldsBuilder = TestDeprecatedFields.Builder.class;
@@ -73,7 +73,7 @@ public class DeprecatedFieldTest extends TestCase {
           isDeprecated(method));
     }
   }
-  
+
   private boolean isDeprecated(AnnotatedElement annotated) {
     return annotated.isAnnotationPresent(Deprecated.class);
   }

--- a/vendor/protobuf-2.6.0/java/src/test/java/com/google/protobuf/DescriptorsTest.java
+++ b/vendor/protobuf-2.6.0/java/src/test/java/com/google/protobuf/DescriptorsTest.java
@@ -497,7 +497,7 @@ public class DescriptorsTest extends TestCase {
       .build();
     // translate and crosslink
     FileDescriptor file =
-      Descriptors.FileDescriptor.buildFrom(fileDescriptorProto, 
+      Descriptors.FileDescriptor.buildFrom(fileDescriptorProto,
           new FileDescriptor[0]);
     // verify resulting descriptors
     assertNotNull(file);
@@ -518,7 +518,7 @@ public class DescriptorsTest extends TestCase {
     }
     assertTrue(barFound);
   }
-  
+
   public void testDependencyOrder() throws Exception {
     FileDescriptorProto fooProto = FileDescriptorProto.newBuilder()
         .setName("foo.proto").build();
@@ -537,14 +537,14 @@ public class DescriptorsTest extends TestCase {
         new FileDescriptor[0]);
     FileDescriptor barFile = Descriptors.FileDescriptor.buildFrom(barProto,
         new FileDescriptor[] {fooFile});
-    
-    // Items in the FileDescriptor array can be in any order. 
+
+    // Items in the FileDescriptor array can be in any order.
     Descriptors.FileDescriptor.buildFrom(bazProto,
         new FileDescriptor[] {fooFile, barFile});
     Descriptors.FileDescriptor.buildFrom(bazProto,
         new FileDescriptor[] {barFile, fooFile});
   }
-  
+
   public void testInvalidPublicDependency() throws Exception {
     FileDescriptorProto fooProto = FileDescriptorProto.newBuilder()
         .setName("foo.proto").build();
@@ -628,7 +628,7 @@ public class DescriptorsTest extends TestCase {
     Descriptors.FileDescriptor.buildFrom(
         fooProto, new FileDescriptor[] {forwardFile});
   }
-  
+
   /**
    * Tests the translate/crosslink for an example with a more complex namespace
    * referencing.
@@ -677,7 +677,7 @@ public class DescriptorsTest extends TestCase {
       assertTrue(field.getEnumType().getFile().getName().equals("bar.proto"));
       assertTrue(field.getEnumType().getFile().getPackage().equals(
           "a.b.c.d.bar.shared"));
-    }   
+    }
   }
 
   public void testOneofDescriptor() throws Exception {

--- a/vendor/protobuf-2.6.0/java/src/test/java/com/google/protobuf/GeneratedMessageTest.java
+++ b/vendor/protobuf-2.6.0/java/src/test/java/com/google/protobuf/GeneratedMessageTest.java
@@ -404,7 +404,7 @@ public class GeneratedMessageTest extends TestCase {
       // We expect this exception.
     }
   }
-  
+
   public void testRepeatedAppendIterateOnlyOnce() throws Exception {
     // Create a Iterable that can only be iterated once.
     Iterable<String> stringIterable = new Iterable<String>() {
@@ -1166,7 +1166,7 @@ public class GeneratedMessageTest extends TestCase {
     FieldDescriptor fieldDescriptor =
         descriptor.findFieldByName("optional_nested_message");
 
-    // Before setting field, builder is initialized by default value. 
+    // Before setting field, builder is initialized by default value.
     TestAllTypes.Builder builder = TestAllTypes.newBuilder();
     NestedMessage.Builder fieldBuilder =
         (NestedMessage.Builder) builder.getFieldBuilder(fieldDescriptor);

--- a/vendor/protobuf-2.6.0/java/src/test/java/com/google/protobuf/LiteralByteStringTest.java
+++ b/vendor/protobuf-2.6.0/java/src/test/java/com/google/protobuf/LiteralByteStringTest.java
@@ -245,7 +245,7 @@ public class LiteralByteStringTest extends TestCase {
     assertTrue(classUnderTest + ".writeTo() must give back the same bytes",
         Arrays.equals(referenceBytes, roundTripBytes));
   }
-  
+
   public void testWriteTo_mutating() throws IOException {
     OutputStream os = new OutputStream() {
       @Override
@@ -286,7 +286,7 @@ public class LiteralByteStringTest extends TestCase {
     assertEquals("Output.reset() resets the output", 0, output.size());
     assertEquals("Output.reset() resets the output",
         ByteString.EMPTY, output.toByteString());
-    
+
   }
 
   public void testToString() throws UnsupportedEncodingException {

--- a/vendor/protobuf-2.6.0/java/src/test/java/com/google/protobuf/MessageTest.java
+++ b/vendor/protobuf-2.6.0/java/src/test/java/com/google/protobuf/MessageTest.java
@@ -312,7 +312,7 @@ public class MessageTest extends TestCase {
       assertEquals("Message missing required fields: a, b, c", e.getMessage());
     }
   }
-  
+
   /** Test reading unset repeated message from DynamicMessage. */
   public void testDynamicRepeatedMessageNull() throws Exception {
     Descriptors.Descriptor descriptor = TestRequired.getDescriptor();
@@ -326,7 +326,7 @@ public class MessageTest extends TestCase {
     assertEquals(result.getRepeatedFieldCount(result.getDescriptorForType()
         .findFieldByName("repeated_foreign_message")), 0);
   }
-  
+
   /** Test reading repeated message from DynamicMessage. */
   public void testDynamicRepeatedMessageNotNull() throws Exception {
 

--- a/vendor/protobuf-2.6.0/java/src/test/java/com/google/protobuf/RopeByteStringSubstringTest.java
+++ b/vendor/protobuf-2.6.0/java/src/test/java/com/google/protobuf/RopeByteStringSubstringTest.java
@@ -35,7 +35,7 @@ import java.util.Iterator;
 
 /**
  * This class tests {@link RopeByteString#substring(int, int)} by inheriting the tests from
- * {@link LiteralByteStringTest}.  Only a couple of methods are overridden.  
+ * {@link LiteralByteStringTest}.  Only a couple of methods are overridden.
  *
  * @author carlanton@google.com (Carl Haverl)
  */

--- a/vendor/protobuf-2.6.0/java/src/test/java/com/google/protobuf/RopeByteStringTest.java
+++ b/vendor/protobuf-2.6.0/java/src/test/java/com/google/protobuf/RopeByteStringTest.java
@@ -37,7 +37,7 @@ import java.util.Iterator;
 /**
  * This class tests {@link RopeByteString} by inheriting the tests from
  * {@link LiteralByteStringTest}.  Only a couple of methods are overridden.
- * 
+ *
  * <p>A full test of the result of {@link RopeByteString#substring(int, int)} is found in the
  * separate class {@link RopeByteStringSubstringTest}.
  *

--- a/vendor/protobuf-2.6.0/java/src/test/java/com/google/protobuf/TextFormatTest.java
+++ b/vendor/protobuf-2.6.0/java/src/test/java/com/google/protobuf/TextFormatTest.java
@@ -861,7 +861,7 @@ public class TextFormatTest extends TestCase {
     TextFormat.merge(TextFormat.printToUnicodeString(message), builder);
     assertEquals(message.getOptionalString(), builder.getOptionalString());
   }
-  
+
   public void testPrintToUnicodeStringWithNewlines() {
     // No newlines at start and end
     assertEquals("optional_string: \"test newlines\n\nin\nstring\"\n",

--- a/vendor/protobuf-2.6.0/java/src/test/java/com/google/protobuf/UnknownFieldSetTest.java
+++ b/vendor/protobuf-2.6.0/java/src/test/java/com/google/protobuf/UnknownFieldSetTest.java
@@ -207,7 +207,7 @@ public class UnknownFieldSetTest extends TestCase {
       TestEmptyMessage.newBuilder().mergeFrom(emptyMessage).clear().build();
     assertEquals(0, message.getSerializedSize());
   }
-  
+
   public void testClearField() throws Exception {
     int fieldNumber = unknownFields.asMap().keySet().iterator().next();
     UnknownFieldSet fields =

--- a/vendor/protobuf-2.6.0/m4/acx_pthread.m4
+++ b/vendor/protobuf-2.6.0/m4/acx_pthread.m4
@@ -55,7 +55,7 @@ dnl @category InstalledPackages
 dnl @author Steven G. Johnson <stevenj@alum.mit.edu>
 dnl @version 2006-05-29
 dnl @license GPLWithACException
-dnl 
+dnl
 dnl Checks for GCC shared/pthread inconsistency based on work by
 dnl Marcin Owsiany <marcin@owsiany.pl>
 
@@ -240,14 +240,14 @@ if test "x$acx_pthread_ok" = xyes; then
 	# architectures and systems. The problem is that in certain
 	# configurations, when -shared is specified, GCC "forgets" to
 	# internally use various flags which are still necessary.
-	
+
 	#
 	# Prepare the flags
 	#
 	save_CFLAGS="$CFLAGS"
 	save_LIBS="$LIBS"
 	save_CC="$CC"
-	
+
 	# Try with the flags determined by the earlier checks.
 	#
 	# -Wl,-z,defs forces link-time symbol resolution, so that the
@@ -259,25 +259,25 @@ if test "x$acx_pthread_ok" = xyes; then
 	CFLAGS="-shared -fPIC -Wl,-z,defs $CFLAGS $PTHREAD_CFLAGS"
 	LIBS="$PTHREAD_LIBS $LIBS"
 	CC="$PTHREAD_CC"
-	
+
 	# In order not to create several levels of indentation, we test
 	# the value of "$done" until we find the cure or run out of ideas.
 	done="no"
-	
+
 	# First, make sure the CFLAGS we added are actually accepted by our
 	# compiler.  If not (and OS X's ld, for instance, does not accept -z),
 	# then we can't do this test.
 	if test x"$done" = xno; then
 	   AC_MSG_CHECKING([whether to check for GCC pthread/shared inconsistencies])
 	   AC_TRY_LINK(,, , [done=yes])
-	
+
 	   if test "x$done" = xyes ; then
 	      AC_MSG_RESULT([no])
 	   else
 	      AC_MSG_RESULT([yes])
 	   fi
 	fi
-	
+
 	if test x"$done" = xno; then
 	   AC_MSG_CHECKING([whether -pthread is sufficient with -shared])
 	   AC_TRY_LINK([#include <pthread.h>],
@@ -285,14 +285,14 @@ if test "x$acx_pthread_ok" = xyes; then
 	      pthread_attr_init(0); pthread_cleanup_push(0, 0);
 	      pthread_create(0,0,0,0); pthread_cleanup_pop(0); ],
 	      [done=yes])
-	   
+
 	   if test "x$done" = xyes; then
 	      AC_MSG_RESULT([yes])
 	   else
 	      AC_MSG_RESULT([no])
 	   fi
 	fi
-	
+
 	#
 	# Linux gcc on some architectures such as mips/mipsel forgets
 	# about -lpthread
@@ -305,7 +305,7 @@ if test "x$acx_pthread_ok" = xyes; then
 	      pthread_attr_init(0); pthread_cleanup_push(0, 0);
 	      pthread_create(0,0,0,0); pthread_cleanup_pop(0); ],
 	      [done=yes])
-	
+
 	   if test "x$done" = xyes; then
 	      AC_MSG_RESULT([yes])
 	      PTHREAD_LIBS="-lpthread $PTHREAD_LIBS"
@@ -324,7 +324,7 @@ if test "x$acx_pthread_ok" = xyes; then
 	        pthread_attr_init(0); pthread_cleanup_push(0, 0);
 	        pthread_create(0,0,0,0); pthread_cleanup_pop(0); ],
 	       [done=yes])
-	
+
 	   if test "x$done" = xyes; then
 	      AC_MSG_RESULT([yes])
 	      PTHREAD_LIBS="-lc_r $PTHREAD_LIBS"
@@ -335,11 +335,11 @@ if test "x$acx_pthread_ok" = xyes; then
 	if test x"$done" = xno; then
 	   # OK, we have run out of ideas
 	   AC_MSG_WARN([Impossible to determine how to use pthreads with shared libraries])
-	
+
 	   # so it's not safe to assume that we may use pthreads
 	   acx_pthread_ok=no
 	fi
-	
+
 	AC_MSG_CHECKING([whether what we have so far is sufficient with -nostdlib])
 	CFLAGS="-nostdlib $CFLAGS"
 	# we need c with nostdlib
@@ -355,7 +355,7 @@ if test "x$acx_pthread_ok" = xyes; then
 	else
 	   AC_MSG_RESULT([no])
 	fi
-	
+
 	if test x"$done" = xno; then
 	   AC_MSG_CHECKING([whether -lpthread saves the day])
 	   LIBS="-lpthread $LIBS"

--- a/vendor/protobuf-2.6.0/m4/libtool.m4
+++ b/vendor/protobuf-2.6.0/m4/libtool.m4
@@ -1196,7 +1196,7 @@ fi
 # Invoke $ECHO with all args, space-separated.
 func_echo_all ()
 {
-    $ECHO "$*" 
+    $ECHO "$*"
 }
 
 case "$ECHO" in

--- a/vendor/protobuf-2.6.0/m4/lt~obsolete.m4
+++ b/vendor/protobuf-2.6.0/m4/lt~obsolete.m4
@@ -25,7 +25,7 @@
 # included after everything else.  This provides aclocal with the
 # AC_DEFUNs it wants, but when m4 processes it, it doesn't do anything
 # because those macros already exist, or will be overwritten later.
-# We use AC_DEFUN over AU_DEFUN for compatibility with aclocal-1.6. 
+# We use AC_DEFUN over AU_DEFUN for compatibility with aclocal-1.6.
 #
 # Anytime we withdraw an AC_DEFUN or AU_DEFUN, remember to add it here.
 # Yes, that means every name once taken will need to remain here until

--- a/vendor/protobuf-2.6.0/python/ez_setup.py
+++ b/vendor/protobuf-2.6.0/python/ez_setup.py
@@ -105,7 +105,7 @@ def use_setuptools(
     try:
         import pkg_resources
     except ImportError:
-        return do_download()       
+        return do_download()
     try:
         return do_download()
         pkg_resources.require("setuptools>="+version); return

--- a/vendor/protobuf-2.6.0/python/google/protobuf/internal/service_reflection_test.py
+++ b/vendor/protobuf-2.6.0/python/google/protobuf/internal/service_reflection_test.py
@@ -80,7 +80,7 @@ class FooUnitTest(basetest.TestCase):
     self.assertEqual('Method Bar not implemented.',
                      rpc_controller.failure_message)
     self.assertEqual(None, self.callback_response)
-    
+
     class MyServiceImpl(unittest_pb2.TestService):
       def Foo(self, rpc_controller, request, done):
         self.foo_called = True

--- a/vendor/protobuf-2.6.0/src/Makefile.in
+++ b/vendor/protobuf-2.6.0/src/Makefile.in
@@ -550,11 +550,11 @@ target_vendor = @target_vendor@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
-@HAVE_ZLIB_FALSE@GZCHECKPROGRAMS = 
+@HAVE_ZLIB_FALSE@GZCHECKPROGRAMS =
 @HAVE_ZLIB_TRUE@GZCHECKPROGRAMS = zcgzip zcgunzip
-@HAVE_ZLIB_FALSE@GZHEADERS = 
+@HAVE_ZLIB_FALSE@GZHEADERS =
 @HAVE_ZLIB_TRUE@GZHEADERS = google/protobuf/io/gzip_stream.h
-@HAVE_ZLIB_FALSE@GZTESTS = 
+@HAVE_ZLIB_FALSE@GZTESTS =
 @HAVE_ZLIB_TRUE@GZTESTS = google/protobuf/io/gzip_stream_unittest.sh
 @GCC_FALSE@NO_OPT_CXXFLAGS = $(PTHREAD_CFLAGS)
 
@@ -1050,7 +1050,7 @@ google/protobuf/io/zero_copy_stream.lo:  \
 google/protobuf/io/zero_copy_stream_impl_lite.lo:  \
 	google/protobuf/io/$(am__dirstamp) \
 	google/protobuf/io/$(DEPDIR)/$(am__dirstamp)
-libprotobuf-lite.la: $(libprotobuf_lite_la_OBJECTS) $(libprotobuf_lite_la_DEPENDENCIES) $(EXTRA_libprotobuf_lite_la_DEPENDENCIES) 
+libprotobuf-lite.la: $(libprotobuf_lite_la_OBJECTS) $(libprotobuf_lite_la_DEPENDENCIES) $(EXTRA_libprotobuf_lite_la_DEPENDENCIES)
 	$(libprotobuf_lite_la_LINK) -rpath $(libdir) $(libprotobuf_lite_la_OBJECTS) $(libprotobuf_lite_la_LIBADD) $(LIBS)
 google/protobuf/stubs/strutil.lo:  \
 	google/protobuf/stubs/$(am__dirstamp) \
@@ -1111,7 +1111,7 @@ google/protobuf/compiler/importer.lo:  \
 google/protobuf/compiler/parser.lo:  \
 	google/protobuf/compiler/$(am__dirstamp) \
 	google/protobuf/compiler/$(DEPDIR)/$(am__dirstamp)
-libprotobuf.la: $(libprotobuf_la_OBJECTS) $(libprotobuf_la_DEPENDENCIES) $(EXTRA_libprotobuf_la_DEPENDENCIES) 
+libprotobuf.la: $(libprotobuf_la_OBJECTS) $(libprotobuf_la_DEPENDENCIES) $(EXTRA_libprotobuf_la_DEPENDENCIES)
 	$(libprotobuf_la_LINK) -rpath $(libdir) $(libprotobuf_la_OBJECTS) $(libprotobuf_la_LIBADD) $(LIBS)
 google/protobuf/compiler/code_generator.lo:  \
 	google/protobuf/compiler/$(am__dirstamp) \
@@ -1242,7 +1242,7 @@ google/protobuf/compiler/python/$(DEPDIR)/$(am__dirstamp):
 google/protobuf/compiler/python/python_generator.lo:  \
 	google/protobuf/compiler/python/$(am__dirstamp) \
 	google/protobuf/compiler/python/$(DEPDIR)/$(am__dirstamp)
-libprotoc.la: $(libprotoc_la_OBJECTS) $(libprotoc_la_DEPENDENCIES) $(EXTRA_libprotoc_la_DEPENDENCIES) 
+libprotoc.la: $(libprotoc_la_OBJECTS) $(libprotoc_la_DEPENDENCIES) $(EXTRA_libprotoc_la_DEPENDENCIES)
 	$(libprotoc_la_LINK) -rpath $(libdir) $(libprotoc_la_OBJECTS) $(libprotoc_la_LIBADD) $(LIBS)
 install-binPROGRAMS: $(bin_PROGRAMS)
 	@$(NORMAL_INSTALL)
@@ -1356,7 +1356,7 @@ google/protobuf/protobuf_lazy_descriptor_test-unittest_no_generic_services.pb.$(
 google/protobuf/compiler/cpp/protobuf_lazy_descriptor_test-cpp_test_bad_identifiers.pb.$(OBJEXT):  \
 	google/protobuf/compiler/cpp/$(am__dirstamp) \
 	google/protobuf/compiler/cpp/$(DEPDIR)/$(am__dirstamp)
-protobuf-lazy-descriptor-test$(EXEEXT): $(protobuf_lazy_descriptor_test_OBJECTS) $(protobuf_lazy_descriptor_test_DEPENDENCIES) $(EXTRA_protobuf_lazy_descriptor_test_DEPENDENCIES) 
+protobuf-lazy-descriptor-test$(EXEEXT): $(protobuf_lazy_descriptor_test_OBJECTS) $(protobuf_lazy_descriptor_test_DEPENDENCIES) $(EXTRA_protobuf_lazy_descriptor_test_DEPENDENCIES)
 	@rm -f protobuf-lazy-descriptor-test$(EXEEXT)
 	$(protobuf_lazy_descriptor_test_LINK) $(protobuf_lazy_descriptor_test_OBJECTS) $(protobuf_lazy_descriptor_test_LDADD) $(LIBS)
 google/protobuf/protobuf_lite_test-lite_unittest.$(OBJEXT):  \
@@ -1374,7 +1374,7 @@ google/protobuf/protobuf_lite_test-unittest_import_lite.pb.$(OBJEXT):  \
 google/protobuf/protobuf_lite_test-unittest_import_public_lite.pb.$(OBJEXT):  \
 	google/protobuf/$(am__dirstamp) \
 	google/protobuf/$(DEPDIR)/$(am__dirstamp)
-protobuf-lite-test$(EXEEXT): $(protobuf_lite_test_OBJECTS) $(protobuf_lite_test_DEPENDENCIES) $(EXTRA_protobuf_lite_test_DEPENDENCIES) 
+protobuf-lite-test$(EXEEXT): $(protobuf_lite_test_OBJECTS) $(protobuf_lite_test_DEPENDENCIES) $(EXTRA_protobuf_lite_test_DEPENDENCIES)
 	@rm -f protobuf-lite-test$(EXEEXT)
 	$(protobuf_lite_test_LINK) $(protobuf_lite_test_OBJECTS) $(protobuf_lite_test_LDADD) $(LIBS)
 google/protobuf/stubs/protobuf_test-common_unittest.$(OBJEXT):  \
@@ -1527,13 +1527,13 @@ google/protobuf/protobuf_test-unittest_no_generic_services.pb.$(OBJEXT):  \
 google/protobuf/compiler/cpp/protobuf_test-cpp_test_bad_identifiers.pb.$(OBJEXT):  \
 	google/protobuf/compiler/cpp/$(am__dirstamp) \
 	google/protobuf/compiler/cpp/$(DEPDIR)/$(am__dirstamp)
-protobuf-test$(EXEEXT): $(protobuf_test_OBJECTS) $(protobuf_test_DEPENDENCIES) $(EXTRA_protobuf_test_DEPENDENCIES) 
+protobuf-test$(EXEEXT): $(protobuf_test_OBJECTS) $(protobuf_test_DEPENDENCIES) $(EXTRA_protobuf_test_DEPENDENCIES)
 	@rm -f protobuf-test$(EXEEXT)
 	$(protobuf_test_LINK) $(protobuf_test_OBJECTS) $(protobuf_test_LDADD) $(LIBS)
 google/protobuf/compiler/main.$(OBJEXT):  \
 	google/protobuf/compiler/$(am__dirstamp) \
 	google/protobuf/compiler/$(DEPDIR)/$(am__dirstamp)
-protoc$(EXEEXT): $(protoc_OBJECTS) $(protoc_DEPENDENCIES) $(EXTRA_protoc_DEPENDENCIES) 
+protoc$(EXEEXT): $(protoc_OBJECTS) $(protoc_DEPENDENCIES) $(EXTRA_protoc_DEPENDENCIES)
 	@rm -f protoc$(EXEEXT)
 	$(CXXLINK) $(protoc_OBJECTS) $(protoc_LDADD) $(LIBS)
 google/protobuf/compiler/test_plugin-mock_code_generator.$(OBJEXT):  \
@@ -1545,19 +1545,19 @@ google/protobuf/testing/test_plugin-file.$(OBJEXT):  \
 google/protobuf/compiler/test_plugin-test_plugin.$(OBJEXT):  \
 	google/protobuf/compiler/$(am__dirstamp) \
 	google/protobuf/compiler/$(DEPDIR)/$(am__dirstamp)
-test_plugin$(EXEEXT): $(test_plugin_OBJECTS) $(test_plugin_DEPENDENCIES) $(EXTRA_test_plugin_DEPENDENCIES) 
+test_plugin$(EXEEXT): $(test_plugin_OBJECTS) $(test_plugin_DEPENDENCIES) $(EXTRA_test_plugin_DEPENDENCIES)
 	@rm -f test_plugin$(EXEEXT)
 	$(CXXLINK) $(test_plugin_OBJECTS) $(test_plugin_LDADD) $(LIBS)
 google/protobuf/testing/zcgunzip.$(OBJEXT):  \
 	google/protobuf/testing/$(am__dirstamp) \
 	google/protobuf/testing/$(DEPDIR)/$(am__dirstamp)
-zcgunzip$(EXEEXT): $(zcgunzip_OBJECTS) $(zcgunzip_DEPENDENCIES) $(EXTRA_zcgunzip_DEPENDENCIES) 
+zcgunzip$(EXEEXT): $(zcgunzip_OBJECTS) $(zcgunzip_DEPENDENCIES) $(EXTRA_zcgunzip_DEPENDENCIES)
 	@rm -f zcgunzip$(EXEEXT)
 	$(CXXLINK) $(zcgunzip_OBJECTS) $(zcgunzip_LDADD) $(LIBS)
 google/protobuf/testing/zcgzip.$(OBJEXT):  \
 	google/protobuf/testing/$(am__dirstamp) \
 	google/protobuf/testing/$(DEPDIR)/$(am__dirstamp)
-zcgzip$(EXEEXT): $(zcgzip_OBJECTS) $(zcgzip_DEPENDENCIES) $(EXTRA_zcgzip_DEPENDENCIES) 
+zcgzip$(EXEEXT): $(zcgzip_OBJECTS) $(zcgzip_DEPENDENCIES) $(EXTRA_zcgzip_DEPENDENCIES)
 	@rm -f zcgzip$(EXEEXT)
 	$(CXXLINK) $(zcgzip_OBJECTS) $(zcgzip_LDADD) $(LIBS)
 

--- a/vendor/protobuf-2.6.0/src/google/protobuf/stubs/structurally_valid.cc
+++ b/vendor/protobuf-2.6.0/src/google/protobuf/stubs/structurally_valid.cc
@@ -524,7 +524,7 @@ InitDetector init_detector;
 
 bool IsStructurallyValidUTF8(const char* buf, int len) {
   if (!module_initialized_) return true;
-  
+
   int bytes_consumed = 0;
   UTF8GenericScanFastAscii(&utf8acceptnonsurrogates_obj,
                            buf, len, &bytes_consumed);


### PR DESCRIPTION
This is part of a whitespace cleanup that I did on both the master and the batch-operation branch so they could diff and merge cleanly and not be filled with spurious formatting changes between them.

Lots of files had trailing whitespace all over, and it differed between the main and the branch, and there was a difference in blank lines (or the absence of) after the new licensing headers too.
 
