### PR TITLE
Add synchronization field to "kinetic-c-util --put" requests.

### DIFF
--- a/src/utility/main.c
+++ b/src/utility/main.c
@@ -595,6 +595,7 @@ void ConfigureEntry(struct UtilConfig * cfg, const char* key, const char* tag,
         .dbVersion = ByteBuffer_Create(cfg->versionData, sizeof(cfg->versionData), 0),
         .algorithm = algorithm,
         .value = ByteBuffer_CreateAndAppendCString(cfg->valueData, sizeof(cfg->valueData), value),
+        .synchronization = KINETIC_SYNCHRONIZATION_WRITETHROUGH,
         .force = force,
     };
 }


### PR DESCRIPTION
Put requests were rejected by Kinetic drives as the value
of synchronization field was not set, thus resulting in
such errors: "Synchronization Field Invalid / Not Provided".

Setting synchronization field to KINETIC_SYNCHRONIZATION_WRITETHROUGH
fixes the "kinetic-c-util --put" command.